### PR TITLE
feat: CI de calidad, check de secretos en pre-commit y guía de actualización de plantilla

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -3,7 +3,11 @@
 Hooks nativos de git que refuerzan el branching de
 [`../CONTRIBUTING.md`](../CONTRIBUTING.md):
 
-- `pre-commit` — bloquea commits directos en `main` / `master` / `develop`.
+- `pre-commit` — bloquea commits directos en `main` / `master` / `develop`, y
+  además rechaza archivos de secretos en stage: `.env` y sus variantes
+  (`.env.local`, `.env.production`…) y claves privadas (`*.pem`, `*.key`,
+  `id_rsa*`, `id_ed25519*`, `id_ecdsa*`). Los contratos de ejemplo
+  (`.env.example`, `.env.sample`, `.env.template`) sí se permiten.
 - `pre-push` — bloquea push directo a esas ramas.
 
 No están activos por defecto. Para habilitarlos en tu clon:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Guardrail opcional: bloquea commits directos en ramas protegidas.
+# Guardrail opcional: bloquea commits directos en ramas protegidas y archivos
+# de secretos en stage.
 # Actívalo en tu clon con:  git config core.hooksPath .githooks
 set -euo pipefail
 
+# 1) git-guardrails: nada de commits directos en ramas protegidas.
 branch="$(git symbolic-ref --short -q HEAD 2>/dev/null || true)"
 case "$branch" in
   main|master|develop)
@@ -10,4 +12,18 @@ case "$branch" in
     exit 1
     ;;
 esac
+
+# 2) secret-guardrails: nada de archivos de secretos en stage. Los contratos
+#    de ejemplo (.env.example / .env.sample / .env.template) sí se permiten.
+while IFS= read -r f; do
+  base="${f##*/}"
+  case "$base" in
+    .env.example|.env.sample|.env.template) continue ;;
+    .env|.env.*|*.pem|*.key|id_rsa*|id_ed25519*|id_ecdsa*)
+      echo "⛔ secret-guardrails: '$f' parece un archivo de secretos — no lo commitees. Usa .env.example como contrato (SECURITY.md, docs/conventions/secrets.md)." >&2
+      exit 1
+      ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACMR)
+
 exit 0

--- a/.github/CODEOWNERS.example
+++ b/.github/CODEOWNERS.example
@@ -1,0 +1,12 @@
+# ==============================================================================
+# CODEOWNERS de ejemplo — renómbralo a `CODEOWNERS` para activarlo.
+# GitHub solicitará revisión automática de los dueños en cada PR que toque
+# sus rutas. Ver https://docs.github.com/articles/about-code-owners
+# ==============================================================================
+
+# Dueño por defecto de todo el repositorio.
+* @[USUARIO_GITHUB]
+
+# Dueños por área (ejemplos — ajusta o elimina).
+# docs/           @[USUARIO_GITHUB]
+# .github/        @[USUARIO_GITHUB]

--- a/.github/scripts/check-links.sh
+++ b/.github/scripts/check-links.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# check-links.sh — verifica que los enlaces relativos entre archivos del repo
+# apunten a archivos que existen. No revisa URLs externas (http/https/mailto)
+# ni destinos con placeholders `[ASÍ]` — solo la red de enlaces internos.
+#
+# Uso:
+#   bash .github/scripts/check-links.sh [raíz-del-repo]
+#
+# Requiere: git, perl. Sale con 1 si hay enlaces rotos.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+broken=0
+
+while IFS= read -r f; do
+  dir="$(dirname "$f")"
+  while IFS= read -r target; do
+    case "$target" in
+      http://*|https://*|mailto:*) continue ;;   # externos: fuera de alcance
+      *'['*) continue ;;                          # contiene un placeholder
+      '') continue ;;
+    esac
+    # Quitar el fragmento #ancla si lo hay.
+    path="${target%%#*}"
+    [ -z "$path" ] && continue
+    if [ ! -e "$dir/$path" ] && [ ! -e "$path" ]; then
+      echo "❌ $f: enlace roto → $target"
+      broken=1
+    fi
+  done < <(perl -CSD -ne 'while (/\]\(([^)\s]+)\)/g) { print "$1\n" }' "$f")
+done < <(git ls-files '*.md')
+
+if [ "$broken" -ne 0 ]; then
+  echo "→ Corrige las rutas o borra los enlaces a documentos eliminados."
+  exit 1
+fi
+echo "✅ Enlaces internos: todos apuntan a archivos existentes."

--- a/.github/scripts/check-parity.sh
+++ b/.github/scripts/check-parity.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# check-parity.sh — compara la estructura de archivos de esta plantilla con la
+# de su variante hermana (es ↔ en) para detectar divergencias entre variantes.
+#
+# EXCLUSIVO DEL REPO-PLANTILLA: este script (y el workflow template-parity.yml
+# que lo ejecuta) no tienen sentido en un proyecto instanciado — bórralos al
+# instanciar la plantilla.
+#
+# Uso:
+#   bash .github/scripts/check-parity.sh <ruta-al-repo-hermano>
+#
+# Compara solo archivos versionados (git ls-files), aplicando el mapa de
+# renombres conocidos entre idiomas.
+set -euo pipefail
+
+SIBLING="${1:?uso: check-parity.sh <ruta-al-repo-hermano>}"
+
+# Mapa de renombres conocidos entre variantes (es ↔ en). Hoy este par no tiene
+# archivos renombrados entre idiomas, así que la normalización es la identidad;
+# si algún archivo cambia de nombre entre variantes, añade aquí el `sed`
+# correspondiente (normalizando ambos lados hacia el nombre en inglés).
+normalize() {
+  cat
+}
+
+mine="$(git ls-files | normalize | sort)"
+theirs="$(git -C "$SIBLING" ls-files | normalize | sort)"
+
+if diff <(printf '%s\n' "$mine") <(printf '%s\n' "$theirs") >/tmp/parity-diff.$$ 2>&1; then
+  echo "✅ Paridad estructural OK con la variante hermana."
+  rm -f "/tmp/parity-diff.$$"
+else
+  echo "❌ Divergencia estructural con la variante hermana:"
+  echo "   («<» solo existe aquí · «>» solo existe en la hermana)"
+  cat "/tmp/parity-diff.$$"
+  rm -f "/tmp/parity-diff.$$"
+  echo "→ Porta el cambio pendiente a la variante hermana o actualiza el mapa de renombres de este script."
+  exit 1
+fi

--- a/.github/scripts/check-placeholders.sh
+++ b/.github/scripts/check-placeholders.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# check-placeholders.sh — verifica los placeholders `[ASÍ]` de la plantilla.
+#
+# Dos modos, autodetectados:
+#   - Modo PLANTILLA (existe TEMPLATE-USAGE.md): todo placeholder usado en el
+#     repo debe estar documentado en el catálogo de TEMPLATE-USAGE.md (§3),
+#     de forma literal o cubierto por un comodín como `[COMANDO_*]`.
+#   - Modo INSTANCIA (TEMPLATE-USAGE.md ya fue borrado): no debe quedar ningún
+#     placeholder sin rellenar, salvo en los esqueletos intencionales.
+#
+# Uso:
+#   bash .github/scripts/check-placeholders.sh [raíz-del-repo]
+#
+# Requiere: git, perl. Sale con 1 si encuentra problemas.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+CATALOG="TEMPLATE-USAGE.md"
+
+# Rutas que se saltan en ambos modos:
+#   - esqueletos que conservan placeholders a propósito (plantillas de docs);
+#   - .github/ (sus corchetes son prefijos de títulos de issue como "[BUG] …").
+SKIP='^(\.github/|docs/conventions/_template\.md|docs/decisions/0000-template\.md)'
+
+# Menciones "meta" sobre el propio sistema de placeholders (no son placeholders
+# que haya que rellenar; aparecen en instrucciones de la plantilla).
+META='^(PLACEHOLDER|PLACEHOLDERS|CORCHETES_EN_MAYÚSCULAS)$'
+
+# Extrae placeholders [MAYÚSCULAS] de un archivo, ignorando los enlaces
+# markdown `[TEXTO](destino)` gracias al lookahead negativo.
+extract() {
+  perl -CSD -ne 'while (/\[([A-ZÁÉÍÓÚÑ0-9_\/]{2,})\](?!\()/g) { print "$ARGV:$.: [$1]\n" }' "$1"
+}
+
+files() {
+  git ls-files '*.md' '.env.example' | grep -Ev "$SKIP" || true
+}
+
+if [ -f "$CATALOG" ]; then
+  # ── Modo PLANTILLA: consistencia del catálogo ──────────────────────────────
+  # Prefijos comodín documentados en el catálogo, p. ej. `[COMANDO_*]` → COMANDO_.
+  wildcards="$(perl -CSD -ne 'while (/\[([A-ZÁÉÍÓÚÑ0-9_\/]+_)\*\]/g) { print "$1\n" }' "$CATALOG" | sort -u)"
+
+  missing=0
+  placeholders="$(
+    files | grep -v "^$CATALOG$" | while IFS= read -r f; do extract "$f"; done \
+      | sed -E 's/^.*\[([^]]+)\]$/\1/' | sort -u
+  )"
+
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    printf '%s' "$p" | grep -Eq "$META" && continue
+    grep -qF "[$p]" "$CATALOG" && continue
+    covered=0
+    while IFS= read -r w; do
+      [ -n "$w" ] && case "$p" in "$w"*) covered=1 ;; esac
+    done <<<"$wildcards"
+    [ "$covered" -eq 1 ] && continue
+    echo "❌ [$p] se usa en el repo pero no está en el catálogo de $CATALOG (§3)."
+    missing=1
+  done <<<"$placeholders"
+
+  if [ "$missing" -ne 0 ]; then
+    echo "→ Añade los placeholders faltantes al catálogo de $CATALOG."
+    exit 1
+  fi
+  echo "✅ Placeholders: todos los usados están documentados en el catálogo."
+else
+  # ── Modo INSTANCIA: no deben quedar placeholders sin rellenar ──────────────
+  leftovers="$(files | while IFS= read -r f; do extract "$f"; done || true)"
+  # También aquí las menciones meta no cuentan como pendientes.
+  leftovers="$(printf '%s' "$leftovers" | grep -Ev '\[(PLACEHOLDER|PLACEHOLDERS|CORCHETES_EN_MAYÚSCULAS)\]' || true)"
+
+  if [ -n "$leftovers" ]; then
+    echo "❌ Quedan placeholders sin rellenar:"
+    printf '%s\n' "$leftovers"
+    echo "→ Rellénalos o borra el documento si no aplica (la plantilla original trae la guía en TEMPLATE-USAGE.md)."
+    exit 1
+  fi
+  echo "✅ Placeholders: no queda ninguno sin rellenar."
+fi

--- a/.github/scripts/tests/run-tests.sh
+++ b/.github/scripts/tests/run-tests.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# run-tests.sh — pruebas de los scripts y hooks de la plantilla.
+# Se ejecutan en CI (workflow quality.yml) y localmente con:
+#   bash .github/scripts/tests/run-tests.sh
+#
+# Requiere: git, perl. Sale con 1 si alguna prueba falla.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PRE_COMMIT="$REPO_ROOT/.githooks/pre-commit"
+PRE_PUSH="$REPO_ROOT/.githooks/pre-push"
+CHECK_PLACEHOLDERS="$REPO_ROOT/.github/scripts/check-placeholders.sh"
+CHECK_LINKS="$REPO_ROOT/.github/scripts/check-links.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# check <descripción> <exit-esperado> <exit-obtenido>
+check() {
+  if [ "$2" -eq "$3" ]; then
+    echo "  ✅ $1"
+    pass=$((pass + 1))
+  else
+    echo "  ❌ $1 (esperado exit=$2, obtenido exit=$3)"
+    fail=$((fail + 1))
+  fi
+}
+
+# Repos git de utilería: en main, en develop y en una rama de feature.
+git -C "$TMP" init -q -b main repo-main
+git -C "$TMP" init -q -b develop repo-develop
+git -C "$TMP" init -q -b feat/x repo-feat
+
+# ── .githooks/pre-commit (protección de ramas) ────────────────────────────────
+echo ".githooks/pre-commit:"
+run_pre_commit() { (cd "$1" && bash "$PRE_COMMIT" 2>/dev/null); }
+
+run_pre_commit "$TMP/repo-main"; check "commit en main → bloquea" 1 $?
+run_pre_commit "$TMP/repo-develop"; check "commit en develop → bloquea" 1 $?
+run_pre_commit "$TMP/repo-feat"; check "commit en rama feat → permite" 0 $?
+
+# ── .githooks/pre-commit (secretos en stage) ──────────────────────────────────
+# Solo si el hook ya trae el check de secretos (guard para commits antiguos).
+if grep -q 'secret-guardrails' "$PRE_COMMIT"; then
+  echo ".githooks/pre-commit (secretos):"
+  # stage_and_check <ruta relativa> <descripción> <exit esperado>
+  stage_and_check() {
+    (cd "$TMP/repo-feat" && mkdir -p "$(dirname "$1")" && printf 'x\n' >"$1" && git add -f "$1")
+    run_pre_commit "$TMP/repo-feat"; check "$2" "$3" $?
+    (cd "$TMP/repo-feat" && git rm -q --cached -f "$1" >/dev/null && rm -f "$1")
+  }
+
+  stage_and_check ".env" "stage .env → bloquea" 1
+  stage_and_check ".env.local" "stage .env.local → bloquea" 1
+  stage_and_check ".env.example" "stage .env.example → permite" 0
+  stage_and_check "certs/server.pem" "stage *.pem → bloquea" 1
+  stage_and_check "certs/server.key" "stage *.key → bloquea" 1
+  stage_and_check "id_rsa" "stage id_rsa → bloquea" 1
+  stage_and_check "notas.md" "stage archivo normal → permite" 0
+fi
+
+# ── .githooks/pre-push (protección de ramas) ──────────────────────────────────
+# El hook lee por stdin una línea por ref: <local ref> <local sha> <remote ref> <remote sha>
+echo ".githooks/pre-push:"
+run_pre_push() { (cd "$TMP/repo-feat" && printf '%s\n' "$1" | bash "$PRE_PUSH" 2>/dev/null); }
+
+run_pre_push "refs/heads/main aaa refs/heads/main bbb"; check "push a main → bloquea" 1 $?
+run_pre_push "refs/heads/x aaa refs/heads/develop bbb"; check "push a develop → bloquea" 1 $?
+run_pre_push "refs/heads/feat/x aaa refs/heads/feat/x bbb"; check "push a rama feat → permite" 0 $?
+(cd "$TMP/repo-feat" && printf '' | bash "$PRE_PUSH" 2>/dev/null); check "push sin refs → permite" 0 $?
+
+# ── check-placeholders.sh ─────────────────────────────────────────────────────
+echo "check-placeholders.sh:"
+make_repo() { # $1 = nombre; crea un repo git en $TMP/$1
+  mkdir -p "$TMP/$1" && git -C "$TMP/$1" init -q -b main
+}
+commit_all() { git -C "$1" add -A && git -C "$1" -c user.email=t@t -c user.name=t commit -qm t; }
+
+# Modo plantilla: placeholder catalogado → pasa.
+make_repo tpl-ok
+printf '| `[NOMBRE_DEL_PROYECTO]` | nombre |\n' >"$TMP/tpl-ok/TEMPLATE-USAGE.md"
+printf '# [NOMBRE_DEL_PROYECTO]\n' >"$TMP/tpl-ok/README.md"
+commit_all "$TMP/tpl-ok"
+(bash "$CHECK_PLACEHOLDERS" "$TMP/tpl-ok" >/dev/null); check "plantilla: catalogado → pasa" 0 $?
+
+# Modo plantilla: placeholder sin catalogar → falla.
+make_repo tpl-bad
+printf '| `[NOMBRE_DEL_PROYECTO]` | nombre |\n' >"$TMP/tpl-bad/TEMPLATE-USAGE.md"
+printf '# [SIN_CATALOGAR]\n' >"$TMP/tpl-bad/README.md"
+commit_all "$TMP/tpl-bad"
+(bash "$CHECK_PLACEHOLDERS" "$TMP/tpl-bad" >/dev/null); check "plantilla: sin catalogar → falla" 1 $?
+
+# Modo plantilla: comodín `[COMANDO_*]` cubre COMANDO_TEST → pasa.
+make_repo tpl-wild
+printf '| `[COMANDO_*]` | comandos |\n' >"$TMP/tpl-wild/TEMPLATE-USAGE.md"
+printf 'Corre [COMANDO_TEST]\n' >"$TMP/tpl-wild/README.md"
+commit_all "$TMP/tpl-wild"
+(bash "$CHECK_PLACEHOLDERS" "$TMP/tpl-wild" >/dev/null); check "plantilla: comodín cubre → pasa" 0 $?
+
+# Modo instancia: queda un placeholder → falla.
+make_repo inst-bad
+printf '# Mi proyecto\nFalta [COMANDO_TEST]\n' >"$TMP/inst-bad/README.md"
+commit_all "$TMP/inst-bad"
+(bash "$CHECK_PLACEHOLDERS" "$TMP/inst-bad" >/dev/null); check "instancia: placeholder pendiente → falla" 1 $?
+
+# Modo instancia: limpio (los enlaces markdown [X](y) no cuentan) → pasa.
+make_repo inst-ok
+printf '# Mi proyecto\nVer [MIT](LICENSE).\n' >"$TMP/inst-ok/README.md"
+commit_all "$TMP/inst-ok"
+(bash "$CHECK_PLACEHOLDERS" "$TMP/inst-ok" >/dev/null); check "instancia: limpio → pasa" 0 $?
+
+# ── check-links.sh ────────────────────────────────────────────────────────────
+echo "check-links.sh:"
+make_repo links-ok
+printf 'Ver [docs](docs/guia.md) y [web](https://example.com) y [ancla](#uso).\n' >"$TMP/links-ok/README.md"
+mkdir -p "$TMP/links-ok/docs" && printf 'hola\n' >"$TMP/links-ok/docs/guia.md"
+commit_all "$TMP/links-ok"
+(bash "$CHECK_LINKS" "$TMP/links-ok" >/dev/null); check "enlaces válidos → pasa" 0 $?
+
+make_repo links-bad
+printf 'Ver [docs](docs/no-existe.md).\n' >"$TMP/links-bad/README.md"
+commit_all "$TMP/links-bad"
+(bash "$CHECK_LINKS" "$TMP/links-bad" >/dev/null); check "enlace roto → falla" 1 $?
+
+# ── Resumen ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Resultado: $pass OK, $fail fallidas."
+[ "$fail" -eq 0 ] || exit 1

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,9 +3,21 @@
 Esta carpeta contiene los workflows de [GitHub Actions](https://docs.github.com/actions)
 del proyecto.
 
-Como la plantilla es agnóstica del stack, **no incluye workflows listos para
-ejecutar**: solo un esqueleto de ejemplo. Adáptalo (o créalo) según tu lenguaje
-y herramientas.
+## Workflows activos (agnósticos del stack)
+
+Funcionan tal cual, sin importar el lenguaje del proyecto — no los borres al instanciar:
+
+- [`quality.yml`](quality.yml) — calidad de la documentación: formato Markdown
+  (Prettier), enlaces internos, placeholders y la suite de pruebas de los scripts del
+  repo (ver [`../scripts/`](../scripts)).
+- [`secret-scan.yml`](secret-scan.yml) — escaneo de secretos con
+  [gitleaks](https://github.com/gitleaks/gitleaks) sobre el historial.
+
+## Exclusivo del repo-plantilla
+
+- [`template-parity.yml`](template-parity.yml) — compara la estructura con la variante
+  hermana en el otro idioma. Tiene un guard por nombre de repositorio para no ejecutarse
+  en proyectos instanciados; aun así, bórralo al instanciar la plantilla.
 
 ## Esqueleto incluido
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,50 @@
+# ==============================================================================
+# Calidad de la documentación — ACTIVO y agnóstico del stack.
+# Funciona tal cual tanto en la plantilla como en los proyectos instanciados:
+#   - formato:      Prettier sobre los archivos Markdown.
+#   - enlaces:      los enlaces relativos entre docs apuntan a archivos reales.
+#   - placeholders: en la plantilla, todo placeholder está en el catálogo de
+#                   TEMPLATE-USAGE.md; en una instancia, no queda ninguno.
+#   - scripts:      la suite de pruebas de los scripts y hooks del repo.
+# ==============================================================================
+
+name: Calidad
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  formato:
+    name: Formato Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prettier --check
+        run: bash .github/scripts/format-markdown.sh --check
+
+  enlaces:
+    name: Enlaces internos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verificar enlaces relativos
+        run: bash .github/scripts/check-links.sh
+
+  placeholders:
+    name: Placeholders
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verificar placeholders
+        run: bash .github/scripts/check-placeholders.sh
+
+  scripts:
+    name: Pruebas de scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Suite de pruebas
+        run: bash .github/scripts/tests/run-tests.sh

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,27 @@
+# ==============================================================================
+# Escaneo de secretos — ACTIVO y agnóstico del stack.
+# Ejecuta gitleaks sobre el historial para detectar credenciales filtradas.
+# Complementa la política de SECURITY.md y docs/conventions/secrets.md.
+# Nota: en repos de una organización, gitleaks-action requiere la variable
+# GITLEAKS_LICENSE (gratis para cuentas personales).
+# ==============================================================================
+
+name: Escaneo de secretos
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-parity.yml
+++ b/.github/workflows/template-parity.yml
@@ -1,0 +1,34 @@
+# ==============================================================================
+# Paridad entre variantes — EXCLUSIVO DEL REPO-PLANTILLA.
+# Compara la estructura de archivos con la variante hermana en inglés para que
+# ningún cambio se quede sin portar. La condición `if` evita que corra en los
+# proyectos instanciados; aun así, bórralo al instanciar la plantilla.
+#
+# En un PR es informativo (continue-on-error): la divergencia es normal hasta
+# que el cambio equivalente aterrice en la variante hermana.
+# ==============================================================================
+
+name: Paridad entre variantes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  paridad:
+    name: Paridad con la variante hermana
+    if: github.repository == 'brayandiazc/project-starter-template-es'
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Checkout de la variante hermana (en)
+        uses: actions/checkout@v7
+        with:
+          repository: brayandiazc/project-starter-template-en
+          path: .sibling
+      - name: Comparar estructura
+        run: bash .github/scripts/check-parity.sh .sibling

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 Descripción breve y concisa del proyecto (1-2 líneas).
 
-![Build](https://img.shields.io/badge/build-passing-brightgreen)
-![Coverage](https://img.shields.io/badge/coverage-0%25-lightgrey)
+![CI](https://github.com/[USUARIO_GITHUB]/[NOMBRE_DEL_PROYECTO]/actions/workflows/ci.yml/badge.svg)
+![Calidad](https://github.com/[USUARIO_GITHUB]/[NOMBRE_DEL_PROYECTO]/actions/workflows/quality.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ## Tabla de Contenidos

--- a/TEMPLATE-USAGE.md
+++ b/TEMPLATE-USAGE.md
@@ -55,27 +55,37 @@ grep -rno '\[[A-ZÁÉÍÓÚÑ0-9_/]\+\]' --include='*.md' --include='.env.exampl
 
 ### Catálogo de placeholders
 
-| Placeholder                                        | Significado                                            |
-| -------------------------------------------------- | ------------------------------------------------------ |
-| `[NOMBRE_DEL_PROYECTO]`                            | Nombre del proyecto                                    |
-| `[NOMBRE_EMPRESA]`                                 | Nombre de la empresa u organización                    |
-| `[AUTOR]`                                          | Nombre del autor o mantenedor principal                |
-| `[USUARIO_GITHUB]`                                 | Usuario u organización de GitHub                       |
-| `[URL_REPOSITORIO]`                                | URL del repositorio                                    |
-| `[AÑO]`                                            | Año del copyright en la licencia                       |
-| `[VERSION]`                                        | Versión (de una dependencia o del proyecto)            |
-| `[FECHA]`                                          | Fecha (formato `YYYY-MM-DD`)                           |
-| `[EMAIL_SOPORTE]`                                  | Correo de contacto/soporte                             |
-| `[EMAIL_SEGURIDAD]`                                | Correo para reportar vulnerabilidades                  |
-| `[RUNTIME]`                                        | Lenguaje/runtime (Node.js, Python, Ruby…)              |
-| `[GESTOR_DE_PAQUETES]`                             | npm, pnpm, bundler, pip…                               |
-| `[BASE_DE_DATOS]`                                  | PostgreSQL, MySQL, MongoDB…                            |
-| `[PUERTO]`                                         | Puerto local de desarrollo                             |
-| `[COMANDO_*]`                                      | Comandos del proyecto (instalar, test, build, deploy…) |
-| `[URL_DEV]` / `[URL_STAGING]` / `[URL_PRODUCCION]` | URLs por ambiente                                      |
-| `[SERVICIO/API]`, `[LINK_*]`, `[OTROS_*]`          | Recursos específicos de tu proyecto                    |
+| Placeholder                                                                                                            | Significado                                             |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `[NOMBRE_DEL_PROYECTO]`                                                                                                | Nombre del proyecto                                     |
+| `[NOMBRE_EMPRESA]`                                                                                                     | Nombre de la empresa u organización                     |
+| `[AUTOR]`                                                                                                              | Nombre del autor o mantenedor principal                 |
+| `[USUARIO_GITHUB]`                                                                                                     | Usuario u organización de GitHub                        |
+| `[URL_REPOSITORIO]`                                                                                                    | URL del repositorio                                     |
+| `[AÑO]`                                                                                                                | Año del copyright en la licencia                        |
+| `[VERSION]`                                                                                                            | Versión (de una dependencia o del proyecto)             |
+| `[FECHA]`                                                                                                              | Fecha (formato `YYYY-MM-DD`)                            |
+| `[EMAIL_SOPORTE]`                                                                                                      | Correo de contacto/soporte                              |
+| `[EMAIL_SEGURIDAD]`                                                                                                    | Correo para reportar vulnerabilidades                   |
+| `[RUNTIME]`                                                                                                            | Lenguaje/runtime (Node.js, Python, Ruby…)               |
+| `[GESTOR_DE_PAQUETES]`                                                                                                 | npm, pnpm, bundler, pip…                                |
+| `[BASE_DE_DATOS]`                                                                                                      | PostgreSQL, MySQL, MongoDB…                             |
+| `[PUERTO]`                                                                                                             | Puerto local de desarrollo                              |
+| `[COMANDO_*]`                                                                                                          | Comandos del proyecto (instalar, test, build, deploy…)  |
+| `[URL_*]` (`[URL_DEV]`, `[URL_BASE_API]`…)                                                                             | URLs por ambiente y recursos web                        |
+| `[SERVICIO/API]`, `[LINK_*]`, `[OTROS_*]`                                                                              | Recursos específicos de tu proyecto                     |
+| `[HERRAMIENTA]`, `[HERRAMIENTA_*]`, `[OTRA_HERRAMIENTA]`                                                               | Herramientas del stack (build, test, e2e, migraciones…) |
+| `[FRAMEWORK_*]`, `[ORM]`, `[LINTER]`, `[FORMATEADOR]`                                                                  | Piezas del stack por rol                                |
+| `[CACHE]`, `[COLA]`, `[CONTENEDORES]`, `[CI_CD]`, `[MONITOREO]`, `[TTL]`                                               | Infraestructura y operaciones                           |
+| `[RUTA_*]`                                                                                                             | Rutas de carpetas/archivos del proyecto                 |
+| `[LAYOUT_*]`, `[LOCALE_*]`, `[AA/AAA]`                                                                                 | UI, i18n y nivel de accesibilidad objetivo              |
+| `[ENTIDAD_*]`, `[COMPONENTE_*]`, `[SERVICIO_*]`, `[ROL_*]`                                                             | Modelo de dominio y arquitectura                        |
+| `[SEGMENTO_*]`, `[PLAN_*]`, `[PRECIO]`, `[PORCENTAJE]`                                                                 | Modelo de negocio                                       |
+| `[ELEGIDA]`, `[DESCARTADA]`, `[ALTERNATIVA]`                                                                           | Comparativas en decisiones (stack, diseño)              |
+| `[TIPO]`, `[OTRO]`, `[EJEMPLO]`, `[COMANDO]`, `[NOMBRES]`, `[PROVEEDOR]`, `[RECURSO]`, `[RIESGO]`, `[OTRAS_VARIABLES]` | Descriptivos locales de cada documento                  |
 
-> Mantén este catálogo actualizado: cualquier `[PLACEHOLDER]` nuevo que introduzcas debería aparecer aquí.
+> Mantén este catálogo actualizado: cualquier `[PLACEHOLDER]` nuevo que introduzcas debería
+> aparecer aquí — el CI lo verifica con `.github/scripts/check-placeholders.sh`.
 
 ## 4. Orden recomendado de llenado
 
@@ -103,6 +113,8 @@ grep -rno '\[[A-ZÁÉÍÓÚÑ0-9_/]\+\]' --include='*.md' --include='.env.exampl
 | `.env.example`                | Contrato de variables de entorno          | Si hay configuración |
 | `.gitignore`, `.editorconfig` | Higiene del repo                          | Recomendado          |
 | `.github/`                    | Plantillas de issues/PR, automatizaciones | Opcional             |
+| `.github/workflows/`          | CI activo (calidad de docs, secretos)     | Recomendado          |
+| `.github/scripts/`            | Scripts de verificación y sus pruebas     | Recomendado          |
 | `docs/architecture/*`         | Documentación técnica                     | Según necesidad      |
 | `docs/product/*`              | Negocio y roadmap                         | Según necesidad      |
 | `docs/decisions/*`            | Registro de decisiones (ADR)              | Recomendado          |
@@ -113,7 +125,11 @@ grep -rno '\[[A-ZÁÉÍÓÚÑ0-9_/]\+\]' --include='*.md' --include='.env.exampl
 - Convenciones de `docs/conventions/` que no uses (p. ej. `i18n.md` si no internacionalizas).
 - Secciones del `README.md` que no apliquen (p. ej. la tabla de Deployment).
 - Documentos de `docs/architecture/` que no correspondan (p. ej. `api.md` si no expones API).
-- Los workflows de ejemplo en `.github/workflows/` si no usas GitHub Actions.
+- Los workflows de ejemplo en `.github/workflows/` si no usas GitHub Actions. Los
+  workflows **activos** (`quality.yml`, `secret-scan.yml`) funcionan en cualquier stack —
+  consérvalos si usas GitHub Actions.
+- **Siempre** borra lo exclusivo del repo-plantilla: `.github/workflows/template-parity.yml`
+  y `.github/scripts/check-parity.sh`.
 
 ## 6. `architecture/X.md` vs `conventions/X.md`
 
@@ -152,8 +168,28 @@ Esta plantilla es **multiplataforma**: el núcleo (gobernanza, arquitectura, dec
 - Cada decisión arquitectónica relevante se registra como un **ADR** en `docs/decisions/` (ver su [README](docs/decisions/README.md)).
 - Mantén `CHANGELOG.md` al día siguiendo [Keep a Changelog](https://keepachangelog.com/es-ES/).
 - Convenciones adicionales (pagos, webhooks, multi-tenancy, PWA, etc.) pueden añadirse usando [`docs/conventions/_template.md`](docs/conventions/_template.md).
+- El CI vigila la salud de los docs (workflow [`quality.yml`](.github/workflows/quality.yml)):
+  formato Markdown, enlaces internos y placeholders pendientes.
 
-## 9. ¿Necesitas IA? Usa la variante con IA
+### Recibir mejoras de la plantilla
+
+La plantilla sigue evolucionando después de que la instancias. Para poder traer esas
+mejoras (nuevos scripts, hooks o workflows) a tu proyecto:
+
+- Al instanciar, anota de qué commit de la plantilla partiste — p. ej. en un archivo
+  `.template-origin` en la raíz con el repo, el commit y la fecha:
+
+  ```text
+  repo: https://github.com/brayandiazc/project-starter-template-es
+  commit: <hash de `git rev-parse HEAD` al instanciar>
+  fecha: YYYY-MM-DD
+  ```
+
+- Cuando quieras sincronizar, descarga la plantilla actual sin su historial
+  (`npx degit brayandiazc/project-starter-template-es .tpl`), compara el tooling
+  (`.github/scripts/`, `.github/workflows/`, `.githooks/`) con el tuyo y aplica a mano
+  lo que convenga — sin tocar tu documentación ya rellenada. Borra `.tpl` al terminar.
+- Sigue los releases/tags del repositorio de la plantilla para saber qué cambió.
 
 Esta plantilla es **deliberadamente sin IA**: se centra en documentación tangible y no incluye estructura ni archivos para flujos de trabajo con agentes.
 


### PR DESCRIPTION
# Descripción

Endurece la plantilla con CI real y agnóstico del stack, un check de secretos en stage dentro del pre-commit nativo, el catálogo de placeholders completo y una guía para recibir mejoras de la plantilla después de instanciarla. Parte de un cambio coordinado en toda la familia de plantillas (PRs gemelos en las variantes hermanas).

## Tipo de Cambio

- [ ] Bug fix
- [x] Nueva funcionalidad
- [ ] Breaking change
- [ ] Refactorización
- [x] Documentación
- [x] Configuración / DevOps

## Cambios Realizados

**Antes**: el repo no tenía ningún check activo (solo `ci.example.yml`); nada impedía commitear archivos `.env` o llaves privadas; el catálogo de placeholders estaba incompleto; no había una forma documentada de traer mejoras de la plantilla a un proyecto ya instanciado ni de mantener la paridad entre variantes de idioma.

**Después**:

- **CI activo y agnóstico del stack** (`quality.yml`): formato Markdown (Prettier), enlaces internos (`check-links.sh`), placeholders (`check-placeholders.sh`, con modo plantilla/instancia autodetectado) y suite de pruebas de los scripts y hooks nativos del repo (21 casos).
- **Escaneo de secretos** (`secret-scan.yml`, gitleaks) y **paridad estructural** con la variante en inglés (`template-parity.yml` + `check-parity.sh`, exclusivo del repo-plantilla).
- **Hook nativo endurecido**: `.githooks/pre-commit` ahora también rechaza archivos de secretos en stage (`.env` y variantes, `*.pem`, `*.key`, `id_rsa*`…), permitiendo `.env.example`.
- **Docs**: catálogo de placeholders completado, guía "Recibir mejoras de la plantilla" (marcador `.template-origin` + comparación del tooling con `npx degit`), badges reales de Actions en el README y `CODEOWNERS.example`.

## Instrucciones de Prueba

1. `bash .github/scripts/tests/run-tests.sh` → 21 OK, 0 fallidas.
2. `bash .github/scripts/check-links.sh && bash .github/scripts/check-placeholders.sh` → ambos ✅.
3. `bash .github/scripts/format-markdown.sh --check` → sin diferencias.
4. `bash .github/scripts/check-parity.sh <ruta-a-en>` → OK una vez fusionado el PR gemelo de `project-starter-template-en`.

## Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión completada
- [x] Código comentado en secciones complejas
- [x] Tests ejecutados exitosamente
- [x] Tests nuevos añadidos (si aplica)
- [x] Sin regresiones en funcionalidad existente
- [x] Documentación actualizada (si aplica)

## Issues Relacionados

Relates to: PRs gemelos en `project-starter-template-en`, `project-starter-template-es-ai` y `project-starter-template-en-ai`.

## Impacto

- **Performance**: Ninguno
- **Breaking changes**: No
- **Requiere migración**: No

## Notas para Revisores

- El workflow de paridad es informativo en PRs (`continue-on-error`): la divergencia es normal hasta que el cambio gemelo aterrice en la variante hermana; en `main` sí falla, como señal de "porteo pendiente".
- `check-placeholders.sh` excluye `.github/` (sus corchetes son prefijos de títulos de issue) y los esqueletos intencionales de docs.
- El check de secretos del pre-commit sigue el modelo opt-in del hook existente (`git config core.hooksPath .githooks`).
