### PR TITLE
docs: convención definition of done

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,7 @@ Resumen de los cambios y qué problema resuelven.
 - [ ] Tests nuevos añadidos (si aplica)
 - [ ] Sin regresiones en funcionalidad existente
 - [ ] Documentación actualizada (si aplica)
+- [ ] Cumple la Definition of Done (`docs/conventions/definition-of-done.md`)
 
 ## Issues Relacionados
 

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -15,6 +15,7 @@ feature concreta.
 | [authentication.md](authentication.md)             | Autenticación y autorización       |
 | [branding.md](branding.md)                         | Identidad de marca y assets        |
 | [database.md](database.md)                         | Modelado de datos y migraciones    |
+| [definition-of-done.md](definition-of-done.md)     | Qué significa "terminado"          |
 | [deploy.md](deploy.md)                             | Despliegue y operaciones           |
 | [design-system.md](design-system.md)               | Sistema de diseño y componentes    |
 | [i18n.md](i18n.md)                                 | Internacionalización               |

--- a/docs/conventions/definition-of-done.md
+++ b/docs/conventions/definition-of-done.md
@@ -1,0 +1,38 @@
+# Definition of Done
+
+> Qué significa "terminado" en [NOMBRE_DEL_PROYECTO]. Si una línea no se puede
+> marcar, el cambio no está terminado — está _declarado_ terminado.
+> **Última actualización**: [FECHA]
+
+## Comportamiento
+
+- [ ] El flujo completo se ejercitó de punta a punta (a mano o con una prueba
+      automatizada de alto nivel), no solo con pruebas unitarias.
+- [ ] El camino feliz **y al menos dos caminos de error** (entrada inválida, fallo
+      de una dependencia) responden de forma sensata.
+- [ ] Los estados de carga, vacío, error y éxito se muestran correctamente (si hay UI).
+
+## Pruebas
+
+- [ ] Existe al menos una prueba que fallaría si el cambio se revirtiera.
+- [ ] Ninguna prueba existente se debilitó, saltó o borró para poner el CI en verde.
+- [ ] La cobertura de las líneas cambiadas es significativa
+      (ver [`testing.md`](testing.md)).
+
+## Interfaces y datos
+
+- [ ] Los cambios de API pública están documentados en
+      [`../architecture/api.md`](../architecture/api.md); los cambios incompatibles
+      tienen nota de migración en el `CHANGELOG.md`.
+- [ ] Los mensajes de error son accionables, no "algo salió mal".
+- [ ] Las migraciones son reversibles y seguras en caliente
+      (ver [`database.md`](database.md)).
+- [ ] No hay secretos en el código ni en los logs (ver [`secrets.md`](secrets.md)).
+
+## Entrega
+
+- [ ] Commits atómicos y legibles según [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md).
+- [ ] La descripción del PR responde el **por qué**, no solo el qué.
+- [ ] Existe un plan de reversa (commit de revert, feature flag apagado, etc.).
+- [ ] La documentación afectada en `docs/` y el `CHANGELOG.md` quedaron al día; las
+      decisiones notables tienen su ADR en [`../decisions/`](../decisions/README.md).


### PR DESCRIPTION
# Descripción

Añade la convención **Definition of Done**: una checklist que define qué significa "terminado" de verdad, para que los PRs no declaren terminado lo que no está verificado. Parte de un cambio coordinado en la familia de plantillas (en las variantes con más tooling incluye además specs numeradas y validaciones de CI adicionales).

## Tipo de Cambio

- [ ] Bug fix
- [x] Nueva funcionalidad
- [ ] Breaking change
- [ ] Refactorización
- [x] Documentación
- [ ] Configuración / DevOps

## Cambios Realizados

**Antes**: "terminado" quedaba a criterio de cada quien; el checklist del PR pedía tests y docs pero sin una definición compartida de completitud.

**Después**: nueva convención `docs/conventions/definition-of-done.md` (comportamiento ejercitado de punta a punta, caminos de error, tests significativos, migraciones seguras, mensajes de error accionables, docs/CHANGELOG al día y plan de reversa), registrada en el índice de convenciones y como ítem nuevo del checklist del PR template.

## Instrucciones de Prueba

1. `bash .github/scripts/check-links.sh && bash .github/scripts/check-placeholders.sh` → ✅.
2. `bash .github/scripts/format-markdown.sh --check` → sin diferencias.
3. `bash .github/scripts/tests/run-tests.sh` → 21 OK, 0 fallidas.

## Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión completada
- [x] Código comentado en secciones complejas
- [x] Tests ejecutados exitosamente
- [ ] Tests nuevos añadidos (si aplica) — no aplica: cambio solo de documentación
- [x] Sin regresiones en funcionalidad existente
- [x] Documentación actualizada (si aplica)

## Issues Relacionados

Relates to: PRs gemelos en las variantes hermanas.

## Impacto

- **Performance**: Ninguno
- **Breaking changes**: No
- **Requiere migración**: No

## Notas para Revisores

El check de paridad marcará divergencia hasta que se fusione el PR gemelo de la variante en inglés, como es habitual.
