### PR TITLE
chore: retirar notas del repo del CHANGELOG-plantilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ### Added
 
-- Workflow `release.yml`: cada merge `develop` → `main` publica automáticamente el
-  tag y el release de GitHub con las notas del CHANGELOG.
-- Workflow `template-update-check.yml`: los proyectos creados desde esta plantilla
-  reciben un issue semanal cuando hay mejoras de tooling pendientes.
-
 - Estructura inicial del proyecto.
 
 ### Changed


### PR DESCRIPTION
El CHANGELOG es contenido que heredan los proyectos derivados; las notas de los workflows nuevos van en el release v1.4.0 del repo, no aquí.