### PR TITLE
ci(secret-scan): dar permisos de lectura de PR a gitleaks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,6 +14,12 @@ on:
   pull_request:
     branches: [main, develop]
 
+# gitleaks-action lee los commits del PR vía API; sin estos permisos el
+# GITHUB_TOKEN devuelve 403 (Resource not accessible by integration).
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   gitleaks:
     name: Gitleaks


### PR DESCRIPTION
# Descripción

`gitleaks-action` lee los commits del PR a través de la API de GitHub. Sin un bloque `permissions` explícito en el workflow, el `GITHUB_TOKEN` puede devolver **403 Resource not accessible by integration**, según cómo esté configurado "Workflow permissions" en cada repositorio. Declarar los permisos mínimos hace que el escaneo funcione igual sin depender de ese ajuste.

## Tipo de Cambio

- [x] Bug fix
- [ ] Nueva funcionalidad
- [ ] Breaking change
- [ ] Refactorización
- [ ] Documentación
- [x] Configuración / DevOps

## Cambios Realizados

**Antes**: `secret-scan.yml` sin bloque `permissions`; los permisos del token dependen de la configuración del repositorio.

**Después**: se declaran los mínimos necesarios, con el porqué en un comentario.

```yaml
permissions:
  contents: read
  pull-requests: read
```

## Instrucciones de Prueba

El propio check **Gitleaks** de este PR es la prueba: corre con los permisos declarados.

## Checklist

- [x] El código sigue las guías de estilo del proyecto
- [x] Auto-revisión completada
- [x] Código comentado en secciones complejas
- [x] Tests ejecutados exitosamente
- [ ] Tests nuevos añadidos (si aplica)
- [x] Sin regresiones en funcionalidad existente
- [x] Documentación actualizada (si aplica)
- [x] Cumple la Definition of Done (`docs/conventions/definition-of-done.md`)

## Impacto

- **Performance**: Ninguno.
- **Breaking changes**: No. Los permisos declarados son **menores** que los que el token podría tener por defecto.
- **Requiere migración**: No.

## Notas para Revisores

Declarar `permissions` a nivel de workflow también reduce el alcance del token al mínimo, que es la práctica recomendada aunque el 403 no se esté dando hoy.
