### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ Todos los cambios notables de este proyecto se documentan en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
+Este es el CHANGELOG del repo-plantilla [brayandiazc/project-starter-template-es](https://github.com/brayandiazc/project-starter-template-es).
+Al instanciar se resetea: tu proyecto hereda las herramientas de la
+plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
+
 ## [Unreleased]
+
+## [2.0.0] - 2026-09-07
 
 ### Added
 
@@ -70,14 +76,13 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ### Security
 
-## [0.1.0] - [FECHA]
+## v1.4.0 y anteriores
 
-### Added
-
-- Versión inicial.
+El historial hasta la `v1.4.0` vive en las [notas de release](https://github.com/brayandiazc/project-starter-template-es/releases)
+del repositorio. No se reconstruye aquí: inventarlo sería peor que no tenerlo.
 
 <!--
-Enlaces de comparación entre versiones (ajusta a tu repositorio):
-[Unreleased]: [URL_REPOSITORIO]/compare/v0.1.0...HEAD
-[0.1.0]: [URL_REPOSITORIO]/releases/tag/v0.1.0
+Enlaces de comparación entre versiones:
+[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v1.4.0...v2.0.0
 -->


### PR DESCRIPTION
# Descripción

Corta la **v2.0.0**: mueve `## [Unreleased]` a `## [2.0.0] - 2026-09-07` y deja los
enlaces de comparación apuntando a la versión nueva. No crea el tag — lo pone
`release.yml` al fusionar en `main`.

**Es un major porque rompe.** Los renombrados de esta versión obligan a migrar a mano en
todo proyecto ya instanciado: un documento renombrado no se sustituye, se duplica, y
ningún check lo detecta. La tabla del `CHANGELOG.md` dice qué mover y qué borrar.

De paso se arregla algo que venía roto de antes: el `CHANGELOG.md` de este repositorio
seguía siendo el **esqueleto de instancia** (`## [0.1.0] - [FECHA]`, «Versión inicial»,
`[URL_REPOSITORIO]`) mientras el repositorio tiene ocho releases publicadas. Eso importa
porque `TEMPLATE-USAGE.md` manda comparar los nombres de archivo contra el CHANGELOG de
la plantilla al actualizar — y ahí no había nada que comparar.

El historial hasta la `v1.4.0` **no se reconstruye**: se apunta a las notas de release,
que es donde está. Inventarlo sería peor que no tenerlo.

## Tipo de cambio

- [x] Documentación

## Cómo comprobar que funciona

1. `bash .github/scripts/check-release.sh .` → v2.0.0 cortada, sin publicar y sin
   trabajo suelto en Unreleased.
2. `bash .github/scripts/tests/run-tests.sh` → 0 fallidas.
3. Al fusionar `develop` → `main`, `release.yml` publica el tag `v2.0.0` y el release.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: sí — ver la tabla de renombrados del `CHANGELOG.md`.
- **Requiere migración**: no en este repo; sí a mano en los proyectos ya instanciados.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
