### PR TITLE
chore(release): v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-07
+
 ### Fixed
 
 - **El workflow de paridad no se ejecutaba nunca en esta variante.** Su condición `if`
@@ -93,6 +95,7 @@ del repositorio. No se reconstruye aquí: inventarlo sería peor que no tenerlo.
 
 <!--
 Enlaces de comparación entre versiones:
-[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v1.4.0...v2.0.0
 -->


### PR DESCRIPTION
# Descripción

Corta la **v2.0.1** con el arreglo del workflow de paridad. No crea el tag — lo pone
`release.yml` al fusionar en `main`.

**Por qué hace falta un patch.** El arreglo llegó a `develop` justo después de que la
v2.0.0 se fusionara en `main`, así que la versión publicada salió con el workflow que
nombra a la variante con IA. Ya está en la calle: no se reescribe, se corrige encima.

## Tipo de cambio

- [x] Corrección de bug
- [x] Documentación

## Cómo comprobar que funciona

1. `bash .github/scripts/check-release.sh .` → v2.0.1 cortada y sin publicar.
2. Al fusionar `develop` → `main`, aparece el tag `v2.0.1` y el release.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
