### PR TITLE
chore(release): v2.0.1 a producción

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,16 +21,16 @@ Funcionan tal cual, sin importar el lenguaje del proyecto — no los borres al i
   desaparecer en silencio la release propia.
 - [`template-update-check.yml`](template-update-check.yml) — **solo actúa en proyectos
   instanciados** (necesita `.template-origin`). Semanalmente compara el tooling con el
-  de la plantilla de origen y abre un issue si hay mejoras. Para aplicarlas:
-  `/actualizar-plantilla`.
+  de la plantilla de origen y abre un issue si hay mejoras. Para aplicarlas, el
+  apartado «Actualizar» de `TEMPLATE-USAGE.md`.
 
 ## Esqueleto incluido
 
 - [`ci.yml.example`](ci.yml.example) — pipeline neutro (lint → test → build). La
   extensión `.example` va **al final a propósito**: GitHub ejecuta cualquier archivo
   `.yml`/`.yaml` que viva en esta carpeta, sin importar qué más lleve en el nombre.
-  `/instanciar` lo renombra a `ci.yml` y sustituye los `[COMANDO_*]` por los del stack
-  elegido. Hasta entonces, el repositorio no ejecuta pruebas de código — solo las
+  Al instanciar, renómbralo a `ci.yml` y sustituye los `[COMANDO_*]` por los de tu
+  stack. Hasta entonces, el repositorio no ejecuta pruebas de código — solo las
   comprobaciones de documentación.
 
 ## Dos reglas de esta carpeta

--- a/.github/workflows/ci.yml.example
+++ b/.github/workflows/ci.yml.example
@@ -6,9 +6,8 @@
 #
 # Para activarlo:
 #   1. Renombra este archivo a `ci.yml`.
-#   2. Reemplaza los pasos [COMANDO_*] por los de tu proyecto (están en AGENTS.md →
-#      "Configuración y comandos", y la skill `/instanciar` los toma del preset de
-#      docs/architecture/stack.md en su Paso 6).
+#   2. Reemplaza los pasos [COMANDO_*] por los de tu proyecto (están en el bloque
+#      «Uso» del README y en docs/architecture/stack.md).
 #   3. Borra esta cabecera.
 #
 # OJO con el nombre: GitHub ejecuta CUALQUIER archivo `.yml`/`.yaml` dentro de

--- a/.github/workflows/template-parity.yml
+++ b/.github/workflows/template-parity.yml
@@ -2,10 +2,10 @@
 # Paridad entre variantes — EXCLUSIVO DEL REPO-PLANTILLA.
 # Compara la estructura de archivos con la variante hermana en inglés para que
 # ningún cambio se quede sin portar. La condición `if` evita que corra en los
-# proyectos instanciados; aun así, la skill /instanciar lo elimina.
+# proyectos instanciados; aun así, TEMPLATE-USAGE.md manda borrarlo al instanciar.
 #
 # En un PR es informativo (continue-on-error): la divergencia es normal hasta
-# que el cambio equivalente aterrice en la variante hermana (skill /portar-cambio).
+# que el cambio equivalente aterrice en la variante hermana.
 # ==============================================================================
 
 name: Paridad entre variantes
@@ -20,15 +20,15 @@ on:
 jobs:
   paridad:
     name: Paridad con la variante hermana
-    if: github.repository == 'brayandiazc/project-starter-template-es-ai'
+    if: github.repository == 'brayandiazc/project-starter-template-es'
     runs-on: ubuntu-latest
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v7
-      - name: Checkout de la variante hermana (en-ai)
+      - name: Checkout de la variante hermana (en)
         uses: actions/checkout@v7
         with:
-          repository: brayandiazc/project-starter-template-en-ai
+          repository: brayandiazc/project-starter-template-en
           path: .sibling
       - name: Comparar estructura
         run: bash .github/scripts/check-parity.sh .sibling

--- a/.github/workflows/template-update-check.yml
+++ b/.github/workflows/template-update-check.yml
@@ -1,10 +1,10 @@
 # template-update-check.yml — avisa cuando la plantilla de origen publica mejoras.
 #
 # Corre semanalmente en los PROYECTOS INSTANCIADOS (necesita `.template-origin`,
-# que escribe /instanciar; si no existe, no hace nada). Compara el commit de la
+# que escribes al instanciar; si no existe, no hace nada). Compara el commit de la
 # plantilla registrado en la instanciación con el HEAD actual del repo-plantilla,
 # limitado a las rutas de tooling, y abre (o actualiza) un issue con el resumen.
-# Para aplicar las mejoras: skill /actualizar-plantilla.
+# Para aplicar las mejoras: el apartado «Actualizar» de TEMPLATE-USAGE.md.
 name: Aviso de mejoras de la plantilla
 
 on:
@@ -71,7 +71,7 @@ jobs:
         run: |
           set -euo pipefail
           title="La plantilla de origen tiene mejoras de tooling pendientes"
-          body="$(printf 'La plantilla de origen cambió su tooling desde la última sincronización (HEAD actual: `%s`).\n\nArchivos afectados:\n\n```\n%s\n```\n\nPara revisar y aplicar las mejoras, corre la skill `/actualizar-plantilla` en Claude Code.\n\n_Issue generado por `.github/workflows/template-update-check.yml`._' "$HEAD" "$FILES")"
+          body="$(printf 'La plantilla de origen cambió su tooling desde la última sincronización (HEAD actual: `%s`).\n\nArchivos afectados:\n\n```\n%s\n```\n\nPara revisar y aplicar las mejoras, sigue el apartado «Actualizar» de `TEMPLATE-USAGE.md`.\n\n_Issue generado por `.github/workflows/template-update-check.yml`._' "$HEAD" "$FILES")"
           existing="$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **El workflow de paridad no se ejecutaba nunca en esta variante.** Su condición `if`
+  y el repositorio hermano seguían nombrando a las variantes con IA, así que el job
+  aparecía como «skipping» en cada PR. Un check que no corre es peor que uno que falla:
+  el segundo avisa. Ahora compara contra `project-starter-template-en`.
+- **Los workflows apuntaban a skills que aquí no existen** (`/instanciar`,
+  `/actualizar-plantilla`) y a `AGENTS.md`, que es de las variantes con IA. Ahora
+  remiten a `TEMPLATE-USAGE.md` y al bloque «Uso» del README, que es lo que hay.
+
 ## [2.0.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-07
+
 ### Fixed
 
 - **El workflow de paridad no se ejecutaba nunca en esta variante.** Su condición `if`
@@ -93,6 +95,7 @@ del repositorio. No se reconstruye aquí: inventarlo sería peor que no tenerlo.
 
 <!--
 Enlaces de comparación entre versiones:
-[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v1.4.0...v2.0.0
 -->


### PR DESCRIPTION
# Descripción

Lleva la **v2.0.1** a producción: fusiona `develop` en `main`. Al fusionar, `release.yml`
crea el tag `v2.0.1` y publica el release.

Contenido: el workflow de paridad llevaba la identidad de la variante con IA
(`if: … == '…-es-ai'`, hermana `…-en-ai`), así que en este repositorio **nunca se
ejecutaba** — aparecía como «skipping» en cada PR, que en la lista de checks se lee casi
igual que un verde. Además, tres workflows remitían a `/instanciar`,
`/actualizar-plantilla` y `AGENTS.md`, que en esta variante no existen.

Se publica como patch porque el arreglo llegó a `develop` justo después de que la v2.0.0
se fusionara en `main`.

## Tipo de cambio

- [x] Corrección de bug
- [x] Configuración / tooling

## Cómo comprobar que funciona

1. **En este PR**: el job «Paridad con la variante hermana» pasa de «skipping» a
   ejecutarse. Puede salir en rojo si la hermana todavía no tiene su v2.0.1 en `main` —
   es informativo (`continue-on-error`) y se resuelve cuando las dos estén.
2. Al fusionar, aparece el tag `v2.0.1` y el release.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
