### PR TITLE
feat(ci): dos checks para las reglas que solo vivían en la prosa

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,6 +27,8 @@ CHECKS=(
 	"Enlaces internos	.github/scripts/check-links.sh"
 	"Placeholders	.github/scripts/check-placeholders.sh"
 	"Herencia de la plantilla	.github/scripts/check-inheritance.sh"
+	"develop existe en el remoto	.github/scripts/check-git-flow.sh"
+	"Identidad de los workflows	.github/scripts/check-workflow-identity.sh"
 	"Design system	.github/scripts/check-design-tokens.sh"
 	"Instrucciones del README	.github/scripts/check-instructions.sh"
 	"Suite de la plantilla	.github/scripts/tests/run-tests.sh"

--- a/.github/scripts/check-git-flow.sh
+++ b/.github/scripts/check-git-flow.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check-git-flow.sh — ¿existe `develop` en el remoto?
+#
+# CONTRIBUTING.md manda que toda rama de trabajo nazca de `develop`, y AGENTS.md
+# lo repite palabra por palabra: «si develop no existe, créala desde main y
+# publícala». Nada lo comprobaba.
+#
+# Por qué importa: una `develop` que solo existe en local cumple la regla al
+# ramificar y la incumple al abrir el PR. `gh pr create --base develop` falla con
+# «Base ref must be a branch», y la salida obvia ante ese error es abrir el PR
+# contra `main` — justo lo que la convención prohíbe. El fallo llega tarde, con
+# el trabajo ya hecho, y su arreglo aparente es el que rompe el flujo.
+#
+# Uso:
+#   bash .github/scripts/check-git-flow.sh [raíz-del-repo]
+#
+# Falla ABIERTO: sin repo git, sin remoto, sin red o en un proyecto que no use
+# Git Flow, no opina. Sale con 1 solo cuando el remoto existe y `develop` no.
+set -uo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT" || exit 0
+
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "ℹ️  Esto no es un repositorio git; nada que verificar."
+  exit 0
+}
+
+# Un proyecto puede haber reescrito su CONTRIBUTING para trabajar solo sobre
+# `main`. Si ahí no se nombra `develop`, no hay Git Flow que hacer cumplir.
+if [ -f CONTRIBUTING.md ] && ! grep -q 'develop' CONTRIBUTING.md; then
+  echo "ℹ️  CONTRIBUTING.md no menciona 'develop'; este proyecto no usa Git Flow."
+  exit 0
+fi
+
+git remote get-url origin >/dev/null 2>&1 || {
+  echo "ℹ️  No hay remoto 'origin'; nada que verificar."
+  exit 0
+}
+
+# `ls-remote` es la única fuente fiable: una `refs/remotes/origin/develop` local
+# puede ser el recuerdo de una rama ya borrada en el servidor.
+if ! salida="$(git ls-remote --heads origin develop 2>/dev/null)"; then
+  echo "ℹ️  No se pudo consultar el remoto (sin red o sin credenciales); se omite."
+  exit 0
+fi
+
+if [ -n "$salida" ]; then
+  echo "✅ Git Flow: 'develop' existe en el remoto."
+  exit 0
+fi
+
+echo "❌ 'develop' no existe en el remoto, pero CONTRIBUTING.md la da por hecha."
+echo "→ Toda rama de trabajo nace de 'develop'. Sin ella publicada, el PR no"
+echo "  tiene base: 'gh pr create --base develop' falla con «Base ref must be a"
+echo "  branch», y abrirlo contra 'main' —la salida obvia— es lo que la"
+echo "  convención prohíbe."
+echo
+echo "   git push origin develop:refs/heads/develop"
+echo
+echo "  (si tampoco la tienes en local: 'git branch develop origin/main' antes)"
+exit 1

--- a/.github/scripts/check-workflow-identity.sh
+++ b/.github/scripts/check-workflow-identity.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-workflow-identity.sh — un workflow que dice ser otro repositorio no corre.
+#
+# Los workflows exclusivos del repo-plantilla se filtran con
+# `if: github.repository == 'usuario/repo'` para no ejecutarse en los proyectos
+# instanciados. Al copiar uno entre repositorios, esa condición viaja tal cual:
+# el job comprueba un repositorio que no es el suyo y **se salta**.
+#
+# Y ahí está el problema: no falla, se salta. En la lista de checks de un PR un
+# «skipping» gris se lee casi igual que un verde, así que la comprobación puede
+# llevar meses sin ejecutarse ni una vez sin que nadie lo note. Un check que no
+# corre es peor que uno que falla, porque el que falla avisa.
+#
+# Solo opina en el REPO-PLANTILLA, que es donde esas condiciones se escriben a
+# mano; lo reconoce por TEMPLATE-USAGE.md. En un proyecto instanciado la
+# condición nombra a la plantilla A PROPÓSITO: es lo que impide que el workflow
+# corra ahí, y acusarlo sería exactamente al revés.
+#
+# Uso:
+#   bash .github/scripts/check-workflow-identity.sh [raíz-del-repo]
+#
+# Falla ABIERTO: fuera del repo-plantilla, o si no se puede saber qué
+# repositorio es este, no opina. Sale con 1 si alguna condición nombra a otro.
+set -uo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT" || exit 0
+
+[ -f TEMPLATE-USAGE.md ] || {
+  echo "ℹ️  Sin TEMPLATE-USAGE.md: esto no es el repo-plantilla; nada que verificar."
+  exit 0
+}
+
+[ -d .github/workflows ] || {
+  echo "ℹ️  No hay .github/workflows/; nada que verificar."
+  exit 0
+}
+
+# En Actions el nombre viene dado; en local se deduce del remoto.
+SLUG="${GITHUB_REPOSITORY:-}"
+if [ -z "$SLUG" ]; then
+  url="$(git remote get-url origin 2>/dev/null || true)"
+  # Sirven las dos formas: git@host:usuario/repo.git y https://host/usuario/repo
+  SLUG="$(printf '%s' "$url" | perl -ne 's/\.git$//; print "$1/$2\n" if m{[:/]([^/:]+)/([^/]+)$}')"
+fi
+
+if [ -z "$SLUG" ]; then
+  echo "ℹ️  No se pudo determinar el repositorio (sin remoto ni GITHUB_REPOSITORY); se omite."
+  exit 0
+fi
+
+fallos=0
+condiciones=0
+
+while IFS= read -r archivo; do
+  # Cada condición `github.repository ==` con un slug literal, con su línea.
+  while IFS=: read -r linea nombrado; do
+    [ -n "$nombrado" ] || continue
+    condiciones=$((condiciones + 1))
+    if [ "$nombrado" != "$SLUG" ]; then
+      if [ "$fallos" -eq 0 ]; then
+        echo "❌ Hay workflows que dicen ser otro repositorio:"
+      fi
+      echo "   · $archivo:$linea → github.repository == '$nombrado'"
+      fallos=$((fallos + 1))
+    fi
+  done < <(perl -ne 'print "$.:$1\n" if /github\.repository\s*==\s*[\x27"]([^\x27"]+)[\x27"]/' "$archivo")
+done < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' -o -name '*.yml.example' \) | sort)
+
+if [ "$fallos" -gt 0 ]; then
+  echo
+  echo "→ Este repositorio es '$SLUG'. Una condición que nombra a otro no falla:"
+  echo "  el job se SALTA, y en la lista de checks un «skipping» gris se lee casi"
+  echo "  igual que un verde. Cámbiala por '$SLUG' o borra el workflow si aquí"
+  echo "  no pinta nada."
+  exit 1
+fi
+
+if [ "$condiciones" -eq 0 ]; then
+  echo "✅ Identidad de los workflows: ninguno se filtra por repositorio."
+else
+  echo "✅ Identidad de los workflows: $condiciones condición(es), todas dicen ser '$SLUG'."
+fi
+exit 0

--- a/.github/scripts/tests/run-tests.sh
+++ b/.github/scripts/tests/run-tests.sh
@@ -11,6 +11,8 @@ CHECK_PLACEHOLDERS="$REPO_ROOT/.github/scripts/check-placeholders.sh"
 CHECK_LINKS="$REPO_ROOT/.github/scripts/check-links.sh"
 CHECK_CHANGELOG="$REPO_ROOT/.github/scripts/check-changelog.sh"
 CHECK_RELEASE="$REPO_ROOT/.github/scripts/check-release.sh"
+CHECK_GIT_FLOW="$REPO_ROOT/.github/scripts/check-git-flow.sh"
+CHECK_WF_IDENTITY="$REPO_ROOT/.github/scripts/check-workflow-identity.sh"
 CHECK_INSTRUCCIONES="$REPO_ROOT/.github/scripts/check-instructions.sh"
 CHECK_HOOKS="$REPO_ROOT/.github/scripts/check-hooks-enabled.sh"
 
@@ -1068,6 +1070,106 @@ if [ -d "$WORKFLOWS" ]; then
   [ -z "$ejemplos_ejecutables" ]
   check "ningún workflow de ejemplo termina en .yml/.yaml" 0 $?
   [ -n "$ejemplos_ejecutables" ] && printf '     · %s\n' $ejemplos_ejecutables
+fi
+
+# ── check-git-flow.sh ─────────────────────────────────────────────────────────
+# La regla «las ramas de trabajo nacen de develop» es incomprobable si develop
+# no está publicada. El fallo aparece tarde —al abrir el PR— y su arreglo
+# aparente (abrirlo contra main) es lo que la convención prohíbe.
+if [ -f "$CHECK_GIT_FLOW" ]; then
+  echo "check-git-flow.sh:"
+
+  # Repo con remoto de verdad: un bare local hace de 'origin'.
+  crea_repo_con_remoto() {
+    mkdir -p "$TMP/$1"
+    git init -q --bare "$TMP/$1-remoto.git"
+    git init -q "$TMP/$1"
+    git -C "$TMP/$1" remote add origin "$TMP/$1-remoto.git"
+    printf 'Las ramas de trabajo nacen de develop.\n' >"$TMP/$1/CONTRIBUTING.md"
+    git -C "$TMP/$1" add -A >/dev/null
+    git -C "$TMP/$1" -c user.email=t@t -c user.name=t commit -qm x
+    git -C "$TMP/$1" push -q origin HEAD:refs/heads/main
+  }
+
+  crea_repo_con_remoto gf-sin
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-sin" >/dev/null 2>&1)
+  check "remoto sin develop → falla" 1 $?
+
+  git -C "$TMP/gf-sin" push -q origin HEAD:refs/heads/develop
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-sin" >/dev/null 2>&1)
+  check "remoto con develop → pasa" 0 $?
+
+  # Una develop solo local no vale: el PR se abre contra el remoto.
+  crea_repo_con_remoto gf-local
+  git -C "$TMP/gf-local" branch develop >/dev/null 2>&1
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-local" >/dev/null 2>&1)
+  check "develop solo en local → falla" 1 $?
+
+  # Proyecto que reescribió CONTRIBUTING para trabajar solo sobre main.
+  crea_repo_con_remoto gf-trunk
+  printf 'Todo sale de main.\n' >"$TMP/gf-trunk/CONTRIBUTING.md"
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-trunk" >/dev/null 2>&1)
+  check "CONTRIBUTING sin 'develop' → no opina" 0 $?
+
+  # Sin remoto no hay nada que comprobar: falla abierto.
+  mkdir -p "$TMP/gf-sin-remoto"
+  git init -q "$TMP/gf-sin-remoto"
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-sin-remoto" >/dev/null 2>&1)
+  check "repo sin remoto → no opina" 0 $?
+
+  mkdir -p "$TMP/gf-no-git"
+  (bash "$CHECK_GIT_FLOW" "$TMP/gf-no-git" >/dev/null 2>&1)
+  check "carpeta sin git → no opina" 0 $?
+fi
+
+# ── check-workflow-identity.sh ────────────────────────────────────────────────
+# Un workflow copiado entre repositorios se trae su `if: github.repository ==`.
+# No falla: se salta. Y un «skipping» gris se lee casi igual que un verde.
+if [ -f "$CHECK_WF_IDENTITY" ]; then
+  echo "check-workflow-identity.sh:"
+
+  crea_wf() {  # $1 = nombre, $2 = slug nombrado en la condición
+    mkdir -p "$TMP/$1/.github/workflows"
+    : >"$TMP/$1/TEMPLATE-USAGE.md"
+    printf "jobs:\n  x:\n    if: github.repository == '%s'\n" "$2" \
+      >"$TMP/$1/.github/workflows/a.yml"
+  }
+
+  crea_wf wf-ajeno otro/repo
+  (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-ajeno" >/dev/null 2>&1)
+  check "condición que nombra a otro repositorio → falla" 1 $?
+
+  crea_wf wf-propio yo/mio
+  (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-propio" >/dev/null 2>&1)
+  check "condición que nombra a este repositorio → pasa" 0 $?
+
+  # Comillas dobles: el YAML admite las dos y la regla no cambia.
+  mkdir -p "$TMP/wf-dobles/.github/workflows"
+  : >"$TMP/wf-dobles/TEMPLATE-USAGE.md"
+  printf 'jobs:\n  x:\n    if: github.repository == "otro/repo"\n' \
+    >"$TMP/wf-dobles/.github/workflows/a.yml"
+  (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-dobles" >/dev/null 2>&1)
+  check "condición entre comillas dobles → también se detecta" 1 $?
+
+  # En un proyecto instanciado la condición nombra a la plantilla A PROPÓSITO:
+  # es lo que impide que el workflow corra ahí. Sin TEMPLATE-USAGE.md, no opina.
+  crea_wf wf-instancia otro/repo
+  rm -f "$TMP/wf-instancia/TEMPLATE-USAGE.md"
+  (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-instancia" >/dev/null 2>&1)
+  check "proyecto instanciado (sin TEMPLATE-USAGE.md) → no opina" 0 $?
+
+  # Sin saber qué repositorio es este, no hay con qué comparar.
+  crea_wf wf-sin-slug otro/repo
+  (cd "$TMP/wf-sin-slug" && GITHUB_REPOSITORY= bash "$CHECK_WF_IDENTITY" . >/dev/null 2>&1)
+  check "sin remoto ni GITHUB_REPOSITORY → no opina" 0 $?
+
+  # Un .yml.example no se ejecuta, pero se copia igual: también se revisa.
+  mkdir -p "$TMP/wf-ejemplo/.github/workflows"
+  : >"$TMP/wf-ejemplo/TEMPLATE-USAGE.md"
+  printf "jobs:\n  x:\n    if: github.repository == 'otro/repo'\n" \
+    >"$TMP/wf-ejemplo/.github/workflows/ci.yml.example"
+  (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-ejemplo" >/dev/null 2>&1)
+  check "condición en un .yml.example → también se revisa" 1 $?
 fi
 
 # ── Resumen ───────────────────────────────────────────────────────────────────

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,8 @@ Funcionan tal cual, sin importar el lenguaje del proyecto — no los borres al i
 
 - [`quality.yml`](quality.yml) — salud de la documentación y del tooling: formato
   Markdown (Prettier), enlaces internos, placeholders, frontmatter de skills y agentes,
-  colores crudos en las vistas, herencia de la plantilla, la suite de pruebas de
+  colores crudos en las vistas, herencia de la plantilla, que `develop` exista en el
+  remoto, que ningún workflow diga ser otro repositorio, la suite de pruebas de
   [`../scripts/`](../scripts) y, en cada PR, la entrada en `CHANGELOG.md` bajo
   `## [Unreleased]` — el label `sin-changelog` es la excepción explícita. En los PRs
   hacia `main` añade el paso de release: nada llega a producción sin versión cortada.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,6 +70,18 @@ jobs:
         if: ${{ !cancelled() }}
         run: bash .github/scripts/check-inheritance.sh
 
+      # La regla «las ramas nacen de develop» es incomprobable si develop no
+      # está publicada, y el fallo solo aparece al abrir el PR.
+      - name: "develop existe en el remoto"
+        if: ${{ !cancelled() }}
+        run: bash .github/scripts/check-git-flow.sh
+
+      # Un workflow copiado se trae su `if: github.repository ==`: entonces no
+      # falla, se salta — y un «skipping» gris se lee casi igual que un verde.
+      - name: Identidad de los workflows
+        if: ${{ !cancelled() }}
+        run: bash .github/scripts/check-workflow-identity.sh
+
       - name: Design system — vistas sin color crudo
         if: ${{ !cancelled() }}
         run: bash .github/scripts/check-design-tokens.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+### Added
+
+- **`check-git-flow.sh` — que `develop` exista en el remoto.** `CONTRIBUTING.md` manda
+  que toda rama de trabajo nazca de `develop`; nada lo comprobaba. Una `develop` que solo existe en local cumple la regla al ramificar y la
+  incumple al abrir el PR: `gh pr create --base develop` falla con «Base ref must be a
+  branch», y la salida obvia ante ese error —abrirlo contra `main`— es justo lo que la
+  convención prohíbe. El fallo llegaba tarde y su arreglo aparente rompía el flujo.
+- **`check-workflow-identity.sh` — que ningún workflow diga ser otro repositorio.** Los
+  workflows exclusivos del repo-plantilla se filtran con
+  `if: github.repository == 'usuario/repo'`. Al copiar uno entre repositorios esa
+  condición viaja tal cual, y entonces el job no falla: **se salta**. En la lista de
+  checks de un PR, un «skipping» gris se lee casi igual que un verde, así que una
+  comprobación puede llevar meses sin ejecutarse ni una vez. Solo opina en el
+  repo-plantilla: en una instancia, la condición nombra a la plantilla a propósito.
+
+  Los dos son el mismo criterio dicho dos veces: **una regla que solo vive en la prosa
+  no se cumple**, y un check que no corre es peor que uno que falla, porque el que falla
+  avisa. El banco de pruebas pasa de 149 a 161 casos.
+
 ## [2.0.1] - 2026-09-07
 
 ### Fixed


### PR DESCRIPTION
# Descripción

Los dos hallazgos de esta semana tenían la misma forma, así que se arreglan igual:
**una regla que solo vive en la prosa no se cumple.** Aquí se convierten en checks.

**`check-git-flow.sh` — que `develop` exista en el remoto.** `CONTRIBUTING.md` manda que
toda rama de trabajo nazca de `develop`, y aun así tres de estos repositorios solo tenían
`main` publicada. El fallo no aparece al ramificar: aparece al abrir el PR, con el
trabajo ya hecho, como `Base ref must be a branch`. Y la salida obvia ante ese error es
abrir el PR contra `main`, que es justo lo que la convención prohíbe.

**`check-workflow-identity.sh` — que ningún workflow diga ser otro repositorio.** Los
workflows exclusivos del repo-plantilla se filtran con
`if: github.repository == 'usuario/repo'`. Al copiar uno entre repositorios esa condición
viaja tal cual, y entonces el job no falla: **se salta**. En la lista de checks, un
«skipping» gris se lee casi igual que un verde — por eso la comparación de paridad entre
las variantes sin IA llevaba sin ejecutarse desde el porte. Un check que no corre es peor
que uno que falla, porque el que falla avisa.

Los dos fallan **abiertos**: sin repo git, sin remoto, sin red, en un proyecto que no use
Git Flow o fuera del repo-plantilla, no opinan. Ese último matiz importa: en un proyecto
instanciado la condición nombra a la plantilla **a propósito**, y acusarlo sería
exactamente al revés.

## Tipo de cambio

- [x] Configuración / tooling

## Cómo comprobar que funciona

1. `bash .github/scripts/check-git-flow.sh .` y `check-workflow-identity.sh .` → verdes.
2. `bash .github/scripts/tests/run-tests.sh` → 0 fallidas, con 12 casos nuevos que
   cubren los dos caminos y los cinco «no opina».
3. Los dos corren en `quality.yml` y en `.githooks/pre-push`.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
