### PR TITLE
fix(ci): Dependabot no podía pasar el gate del CHANGELOG

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,19 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Un PR con todas las actions en vez de uno por action: aquí no hay lockfile,
+    # así que agrupar es solo menos ruido. Donde de verdad importa es abajo.
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "ci-cd"
+      # Dependabot no escribe el CHANGELOG, ni puede aprenderlo: sin esto, el
+      # job `changelog` de quality.yml tumba TODOS sus PRs con el resto en
+      # verde. La excepción ya estaba diseñada; ahora nacen con ella puesta.
+      - "sin-changelog"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -36,7 +46,17 @@ updates:
   #   target-branch: "develop"
   #   schedule:
   #     interval: "weekly"
-  #   labels: ["dependencies"]
+  #   # UN solo PR con todos los bumps, no uno por paquete. Fusionar N bumps
+  #   # sueltos en cadena deja un lockfile que nadie compiló: git no marca
+  #   # conflicto —cada bump toca un sitio distinto del archivo— y el CI
+  #   # tampoco lo ve, porque cada PR se construye sobre su propia rama, nunca
+  #   # sobre el resultado de fusionarlos todos. Agrupados, ese estado SÍ pasa
+  #   # por el build. El precio: si un bump del grupo rompe, se bloquea el
+  #   # grupo entero y hay que averiguar cuál fue.
+  #   groups:
+  #     dependencias:
+  #       patterns: ["*"]
+  #   labels: ["dependencies", "sin-changelog"]
   #
   # - package-ecosystem: "pip"        # Python
   #   directory: "/"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,6 +36,14 @@ name: Calidad
 on:
   pull_request:
     branches: [main, develop]
+    # `labeled`/`unlabeled` no sobran: `PR_LABELS` sale del payload del evento
+    # (`github.event.pull_request.labels`). Sin ellos, poner la label
+    # `sin-changelog` a mano no dispara nada, y un re-run replica el payload
+    # viejo — sin la label. La vía de escape solo servía puesta ANTES de abrir
+    # el PR, justo al revés de cuando descubres que la necesitas.
+    #
+    # El precio: cada cambio de label vuelve a correr el job entero.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Un push nuevo al PR cancela la ejecución anterior: durante el desarrollo
 # activo es donde más presupuesto se va.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dependabot no podía pasar el gate del CHANGELOG.** El job `changelog` exige entrada a
+  todo PR que toque el proyecto; el bot toca el manifiesto y el lockfile, no escribe
+  changelogs y no puede aprenderlo. Sus PRs morían con el build y los escaneos en verde.
+  La excepción ya estaba diseñada —la label `sin-changelog`—, solo que nada se la ponía:
+  ahora nacen con ella.
+- **La vía de escape solo servía puesta antes de abrir el PR.** `PR_LABELS` sale del
+  payload del evento, así que poner `sin-changelog` a mano no disparaba nada y un re-run
+  replicaba el payload viejo, sin la label — justo al revés de cuando descubres que la
+  necesitas. `quality.yml` escucha ahora `labeled` y `unlabeled`. Cuesta un run por cada
+  cambio de label; una salida de emergencia inutilizable en la emergencia cuesta más.
+
+- **`check-hooks-enabled.sh` no lo invocaba nadie.** Existía, tenía sus casos en el banco
+  de pruebas y ninguna otra línea del repositorio lo llamaba: las dos llamadas vivían en
+  skills que esta variante no tiene. Y por diseño no puede correr en el CI —no ve la
+  config local de nadie— ni dentro de `pre-push` —solo se ejecuta si la config que
+  verifica ya está puesta—, así que sin una instrucción que lo llame no lo llama nadie.
+  `TEMPLATE-USAGE.md` lo invoca ahora en lugar de mandar el `git config` a pelo.
+- **`TEMPLATE-USAGE.md` remitía a skills que aquí no existen** (`/actualizar-plantilla`).
+  Ahora describe el paso en vez de delegarlo en algo que no está.
+
+### Changed
+
+- **Los PRs de Dependabot van agrupados**, uno con todos los bumps en vez de uno por
+  paquete. Fusionar N bumps sueltos en cadena deja un lockfile que nadie compiló: git no
+  marca conflicto —cada bump toca un sitio distinto del archivo— y el CI tampoco lo ve,
+  porque cada PR se construye sobre su propia rama y nunca sobre el resultado de
+  fusionarlos todos. El precio, escrito al lado en `dependabot.yml`: si un bump del grupo
+  rompe, se bloquea el grupo entero.
+
 ## [2.1.0] - 2026-09-07
 
 ### Added

--- a/TEMPLATE-USAGE.md
+++ b/TEMPLATE-USAGE.md
@@ -67,16 +67,20 @@ sabes cuáles son en vez de descubrirlo cuando ya se perdieron.
   adoptaste una versión anterior, algún documento tuyo puede llamarse ahora de otra
   forma. Traer el nuevo sin borrar el viejo **deja los dos**, con contenido distinto y
   sin que ningún check lo note.
-- Activa los git hooks: `git config core.hooksPath .githooks`.
+- Activa los git hooks: `bash .github/scripts/check-hooks-enabled.sh --arreglar`.
+  Hace lo mismo que `git config core.hooksPath .githooks` y además comprueba que sean
+  ejecutables. Este check no puede correr en el CI —no ve la config local de nadie— ni
+  dentro de `pre-push` —solo se ejecuta si la config que verifica ya está puesta—, así
+  que si no lo llamas aquí, no lo llama nadie.
 - Escribe `.template-origin` (repo, commit, fecha y `versiones=` con las versiones
   del CHANGELOG de la plantilla — sin ellas, `check-inheritance.sh` cae a un criterio
-  por fecha que puede acusar un release tuyo del mismo día) para que
-  `/actualizar-plantilla` y el workflow de avisos funcionen de aquí en adelante.
+  por fecha que puede acusar un release tuyo del mismo día) para que el workflow de
+  avisos funcione de aquí en adelante.
 - Rellena los `docs/` nuevos con lo que ya sabes del proyecto en vez de dejar placeholders.
 - Commitea en la rama, abre un PR y luego borra `TEMPLATE-USAGE.md`.
 
-> Si tu proyecto **ya tenía** una versión de esta plantilla, el camino corto es
-> `/actualizar-plantilla`, que hace todo esto y además calcula el diff del tooling.
+> Si tu proyecto **ya tenía** una versión de esta plantilla, calcula el diff del tooling
+> entre tu commit de origen y el HEAD de la plantilla, y aplica solo eso.
 
 ## 3. Reemplazar los placeholders
 


### PR DESCRIPTION
# Descripción

Tres arreglos que vienen de `brayandiazc.com`, donde se cobraron un mes de PRs en rojo y
una `develop` que no instalaba.

**1. Dependabot no podía pasar el gate del CHANGELOG.** El job `changelog` exige entrada
a todo PR que toque el proyecto. El bot toca el manifiesto y el lockfile, no escribe
changelogs y **no puede aprenderlo**: sus PRs morían con el build y los escaneos en
verde. La excepción ya estaba diseñada —la label `sin-changelog`—, solo que nada se la
ponía. Ahora nacen con ella.

**2. La vía de escape solo servía puesta antes de abrir el PR.** `PR_LABELS` sale del
payload del evento, así que poner la label a mano no disparaba nada, y un re-run
replicaba el payload viejo, sin ella. Justo al revés de cuando descubres que la
necesitas. `quality.yml` escucha ahora `labeled` y `unlabeled`. Cuesta un run por cada
cambio de label; una salida de emergencia inutilizable en la emergencia cuesta más.

**3. Los PRs de Dependabot van agrupados.** Fusionar N bumps sueltos en cadena deja un
lockfile que nadie compiló: git no marca conflicto —cada bump toca un sitio distinto del
archivo— y el CI tampoco lo ve, porque cada PR se construye sobre su propia rama y nunca
sobre el resultado de fusionarlos todos. En `brayandiazc.com` eso dejó `picomatch@4.0.7`
triplicado y `develop` sin instalar. El precio de agrupar queda escrito al lado en
`dependabot.yml`: si un bump del grupo rompe, se bloquea el grupo entero.

**4. Y uno de casa: `check-hooks-enabled.sh` no lo invocaba nadie.** Existía, tenía sus
casos en el banco de pruebas y ninguna otra línea del repositorio lo llamaba — las dos
llamadas vivían en skills que esta variante no tiene. Por diseño no puede correr en el CI
—no ve la config local de nadie— ni dentro de `pre-push` —solo se ejecuta si la config que
verifica ya está puesta—, así que sin una instrucción que lo llame, no lo llama nadie.
`TEMPLATE-USAGE.md` lo invoca ahora en lugar de mandar el `git config` a pelo, y de paso
deja de remitir a `/actualizar-plantilla`, que aquí tampoco existe.

**Lo que no se trae de ese repo**: la cadencia mensual (cosmética al lado de agrupar, y
con las alertas de seguridad apagadas estira la ventana de exposición — aquí se queda en
`weekly`), los `ignore` de paquetes atados a su stack, y el cron de su despliegue.

## Tipo de cambio

- [x] Corrección de bug
- [x] Configuración / tooling

## Cómo comprobar que funciona

1. `ruby -ryaml -e 'YAML.load_file(ARGV[0])' .github/dependabot.yml` → parsea.
2. `bash .github/scripts/tests/run-tests.sh` → 0 fallidas.
3. El siguiente PR de Dependabot nace con `sin-changelog` y pasa el job `Calidad`.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no — al contrario, agrupar baja el número de PRs.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
