### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-07
+
 ### Fixed
 
 - **Dependabot no podía pasar el gate del CHANGELOG.** El job `changelog` exige entrada a
@@ -147,7 +149,8 @@ del repositorio. No se reconstruye aquí: inventarlo sería peor que no tenerlo.
 
 <!--
 Enlaces de comparación entre versiones:
-[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v1.4.0...v2.0.0


### PR DESCRIPTION
# Descripción

Corta la versión con los arreglos de Dependabot. No crea el tag — lo pone `release.yml` al
fusionar en `main`.

**Es minor, no patch.** Dos de los tres cambios reparan algo roto, pero el tercero cambia
comportamiento: los PRs de Dependabot pasan a venir **agrupados**, uno con todos los bumps
en vez de uno por paquete. Quien adopte esta versión verá otra cosa, no lo mismo arreglado.

## Tipo de cambio

- [x] Documentación

## Cómo comprobar que funciona

1. `bash .github/scripts/check-release.sh .` → cortada y sin publicar.
2. Al fusionar `develop` → `main`, aparecen el tag y el release.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
