### PR TITLE
feat(ci): check-labels — declarar una label no la crea

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -29,6 +29,7 @@ CHECKS=(
 	"Herencia de la plantilla	.github/scripts/check-inheritance.sh"
 	"develop existe en el remoto	.github/scripts/check-git-flow.sh"
 	"Identidad de los workflows	.github/scripts/check-workflow-identity.sh"
+	"Labels declaradas y creadas	.github/scripts/check-labels.sh"
 	"Design system	.github/scripts/check-design-tokens.sh"
 	"Instrucciones del README	.github/scripts/check-instructions.sh"
 	"Suite de la plantilla	.github/scripts/tests/run-tests.sh"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Pasos concretos para verificar el resultado, no el código:
 
 > El CI ya verifica formato, enlaces, entrada en el CHANGELOG y la suite de tests: no
 > hay casillas para eso. Aquí van solo las cosas que **fallan en silencio** — pasan los
-> tests y no generan un error en el monitor (`docs/conventions/ai-agents.md`).
+> tests y no generan un error en el monitor.
 
 - [ ] **Esquema de datos revisado a mano** — obligatorio si hay migración. Es lo más
       caro de cambiar después y lo único que ni los tests ni el monitoreo detectan.

--- a/.github/scripts/check-labels.sh
+++ b/.github/scripts/check-labels.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# check-labels.sh — las labels de LABELS.md, ¿existen de verdad en el repositorio?
+#
+# `.github/LABELS.md` es la fuente única y `setup-labels.sh` las crea a partir de
+# sus tablas. Pero crear las labels es un paso MANUAL que se hace una vez por
+# repositorio, y nada comprobaba que se hubiera hecho.
+#
+# Por qué importa más de lo que parece: hay mecanismos que dependen de que la
+# label exista, no de que esté escrita. `dependabot.yml` declara `sin-changelog`
+# en sus PRs para que el job del changelog los deje pasar — si la label no está
+# creada, Dependabot no puede aplicarla, el gate los tumba igual, y el arreglo
+# parece hecho porque el archivo dice lo correcto. La vía de escape manual
+# tampoco sirve: no puedes ponerle al PR una label que no existe.
+#
+# Uso:
+#   bash .github/scripts/check-labels.sh [raíz-del-repo]
+#
+# Falla ABIERTO: sin `gh`, sin autenticación, sin remoto o sin LABELS.md, no
+# opina. Sale con 1 solo cuando puede listar las labels y falta alguna.
+set -uo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT" || exit 0
+
+LABELS_MD=".github/LABELS.md"
+
+[ -f "$LABELS_MD" ] || {
+  echo "ℹ️  No hay $LABELS_MD; nada que verificar."
+  exit 0
+}
+
+command -v gh >/dev/null 2>&1 || {
+  echo "ℹ️  No está instalado 'gh'; se omite la verificación de labels."
+  exit 0
+}
+
+# El repositorio: en Actions viene dado; en local se deduce del remoto.
+SLUG="${GITHUB_REPOSITORY:-}"
+if [ -z "$SLUG" ]; then
+  url="$(git remote get-url origin 2>/dev/null || true)"
+  SLUG="$(printf '%s' "$url" | perl -ne 's/\.git$//; print "$1/$2\n" if m{[:/]([^/:]+)/([^/]+)$}')"
+fi
+
+[ -n "$SLUG" ] || {
+  echo "ℹ️  No se pudo determinar el repositorio; se omite."
+  exit 0
+}
+
+if ! existentes="$(gh label list -R "$SLUG" --limit 200 --json name -q '.[].name' 2>/dev/null)"; then
+  echo "ℹ️  No se pudieron listar las labels (sin autenticación o sin red); se omite."
+  exit 0
+fi
+
+# Las tablas de LABELS.md: | `nombre` | `#RRGGBB` | descripción |
+declaradas="$(perl -ne 'print "$1\n" if /^\|\s*`([^`]+)`\s*\|\s*`#[0-9A-Fa-f]{6}`\s*\|/' "$LABELS_MD")"
+
+[ -n "$declaradas" ] || {
+  echo "ℹ️  $LABELS_MD no declara ninguna label parseable; nada que verificar."
+  exit 0
+}
+
+faltan=""
+total=0
+while IFS= read -r l; do
+  [ -n "$l" ] || continue
+  total=$((total + 1))
+  printf '%s\n' "$existentes" | grep -qxF "$l" || faltan="$faltan $l"
+done <<EOF
+$declaradas
+EOF
+
+if [ -n "$faltan" ]; then
+  echo "❌ Estas labels están en $LABELS_MD pero no existen en $SLUG:"
+  for l in $faltan; do echo "   · $l"; done
+  echo "→ Declararlas no las crea. Y hay mecanismos que dependen de que existan:"
+  echo "  'dependabot.yml' pone 'sin-changelog' a sus PRs para pasar el gate del"
+  echo "  changelog — sin la label creada, el gate los tumba igual y el arreglo"
+  echo "  parece hecho porque el archivo dice lo correcto."
+  echo
+  echo "   bash .github/scripts/setup-labels.sh"
+  exit 1
+fi
+
+echo "✅ Labels: las $total de $LABELS_MD existen en $SLUG."
+exit 0

--- a/.github/scripts/tests/run-tests.sh
+++ b/.github/scripts/tests/run-tests.sh
@@ -13,6 +13,7 @@ CHECK_CHANGELOG="$REPO_ROOT/.github/scripts/check-changelog.sh"
 CHECK_RELEASE="$REPO_ROOT/.github/scripts/check-release.sh"
 CHECK_GIT_FLOW="$REPO_ROOT/.github/scripts/check-git-flow.sh"
 CHECK_WF_IDENTITY="$REPO_ROOT/.github/scripts/check-workflow-identity.sh"
+CHECK_LABELS="$REPO_ROOT/.github/scripts/check-labels.sh"
 CHECK_INSTRUCCIONES="$REPO_ROOT/.github/scripts/check-instructions.sh"
 CHECK_HOOKS="$REPO_ROOT/.github/scripts/check-hooks-enabled.sh"
 
@@ -74,7 +75,7 @@ commit_all "$TMP/inst-ok"
 (bash "$CHECK_PLACEHOLDERS" "$TMP/inst-ok" >/dev/null); check "instancia: limpio → pasa" 0 $?
 
 # Modo instancia: placeholder MARCADO como pendiente → pasa.
-# /instanciar dice "no inventes datos, deja el placeholder"; sin esta excepción esa
+# La instanciación dice "no inventes datos, deja el placeholder"; sin esta excepción esa
 # regla y este check se contradicen y el primer PR de todo proyecto sale en rojo.
 make_repo inst-pend
 printf '# Mi proyecto\nContacto: [EMAIL_SOPORTE] <!-- pendiente: aún sin buzón -->\n' >"$TMP/inst-pend/README.md"
@@ -286,7 +287,7 @@ commit_all "$TMP/inst-github-ok"
 salida_gh="$(bash "$CHECK_PLACEHOLDERS" "$TMP/inst-github-ok" 2>&1 || true)"
 printf '%s' "$salida_gh" | grep -q "no queda ninguno"; check "instancia: el resumen no lista [BUG] como pendiente" 0 $?
 
-# --rutas-sustituibles: el alcance de la pasada de relleno de /instanciar. La pasada
+# --rutas-sustituibles: el alcance de la pasada de relleno al instanciar. La pasada
 # global corrompió los fixtures de ESTE banco y rellenó las plantillas internas de
 # specs/ y docs/, que existen para conservar sus placeholders — lo segundo se cobró
 # semanas después, cuando spec-guardrails acusó de "sin rellenar" la línea que sí lo
@@ -797,7 +798,7 @@ if [ -f "$CHECK_HERENCIA" ]; then
 
   # ── --version-publicable ───────────────────────────────────────────────────
   # La guarda que impide publicar la release DE LA PLANTILLA. Pasó de verdad:
-  # /instanciar crea main en el Paso 0 apuntando al commit inicial (CHANGELOG
+  # Al instanciar, main se crea apuntando al commit inicial (CHANGELOG
   # heredado) y el push de main dispara release.yml, que publicó un v1.0.0 con
   # las notas del repo origen. Y lo caro venía después: el día que el proyecto
   # llegue a su propia v1.0.0, release.yml diría "ya tiene tag" y se saltaría
@@ -934,7 +935,7 @@ if [ -f "$CHECK_INSTRUCCIONES" ]; then
   run_instr in-comentado; check "instrucciones: variables solo comentadas → falla" 1 $?
 
   # Sin la línea del README no hay nada que reprochar, aunque el archivo esté vacío:
-  # conservar .env.example vacío CON su explicación es lo que manda /instanciar.
+  # conservar .env.example vacío CON su explicación es lo que manda TEMPLATE-USAGE.md.
   instr in-podado
   printf '# Ninguna variable todavía.\n' >"$TMP/in-podado/.env.example"
   printf '# P\n\n```bash\ngit clone x\n```\n' >"$TMP/in-podado/README.md"
@@ -1170,6 +1171,66 @@ if [ -f "$CHECK_WF_IDENTITY" ]; then
     >"$TMP/wf-ejemplo/.github/workflows/ci.yml.example"
   (GITHUB_REPOSITORY=yo/mio bash "$CHECK_WF_IDENTITY" "$TMP/wf-ejemplo" >/dev/null 2>&1)
   check "condición en un .yml.example → también se revisa" 1 $?
+fi
+
+# ── check-labels.sh ───────────────────────────────────────────────────────────
+# Declarar una label no la crea. Y hay mecanismos que dependen de que exista:
+# dependabot.yml pone `sin-changelog` a sus PRs para pasar el gate del changelog
+# — sin la label creada el gate los tumba igual, y el arreglo parece hecho
+# porque el archivo dice lo correcto.
+if [ -f "$CHECK_LABELS" ]; then
+  echo "check-labels.sh:"
+
+  # `gh` de mentira: imprime las labels que le pasemos por LABELS_FALSAS.
+  mkdir -p "$TMP/bin"
+  cat >"$TMP/bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "label" ]; then printf '%s\n' ${LABELS_FALSAS:-}; exit 0; fi
+exit 0
+GHSTUB
+  chmod +x "$TMP/bin/gh"
+
+  crea_labels_md() {  # $1 = nombre, $2 = labels declaradas separadas por espacios
+    mkdir -p "$TMP/$1/.github"
+    {
+      printf '# Labels\n\n| Label | Color | Qué significa |\n| --- | --- | --- |\n'
+      for l in $2; do printf '| `%s` | `#FF0000` | x |\n' "$l"; done
+    } >"$TMP/$1/.github/LABELS.md"
+  }
+
+  corre_labels() {  # $1 = carpeta, $2 = labels que "existen" en el repo
+    (PATH="$TMP/bin:$PATH" LABELS_FALSAS="$2" GITHUB_REPOSITORY=yo/mio \
+      bash "$CHECK_LABELS" "$TMP/$1" >/dev/null 2>&1)
+  }
+
+  crea_labels_md lb-completo "bug ci-cd sin-changelog"
+  corre_labels lb-completo "bug ci-cd sin-changelog"
+  check "todas las declaradas existen → pasa" 0 $?
+
+  crea_labels_md lb-falta "bug ci-cd sin-changelog"
+  corre_labels lb-falta "bug ci-cd"
+  check "falta una label declarada → falla" 1 $?
+
+  # El caso real que motivó el check: el repo solo tiene las de fábrica.
+  crea_labels_md lb-fabrica "sin-changelog dependencies"
+  corre_labels lb-fabrica "bug documentation duplicate enhancement question wontfix"
+  check "repo solo con labels de fábrica → falla" 1 $?
+
+  # Falla abierto: sin tablas parseables no hay nada declarado que exigir.
+  mkdir -p "$TMP/lb-sin-tabla/.github"
+  printf '# Labels\n\nprosa sin tablas\n' >"$TMP/lb-sin-tabla/.github/LABELS.md"
+  corre_labels lb-sin-tabla "bug"
+  check "LABELS.md sin tablas → no opina" 0 $?
+
+  mkdir -p "$TMP/lb-sin-md"
+  corre_labels lb-sin-md "bug"
+  check "repo sin LABELS.md → no opina" 0 $?
+
+  # Sin saber qué repositorio es este no hay a quién preguntarle.
+  crea_labels_md lb-sin-slug "sin-changelog"
+  (cd "$TMP/lb-sin-slug" && PATH="$TMP/bin:$PATH" GITHUB_REPOSITORY= \
+    bash "$CHECK_LABELS" . >/dev/null 2>&1)
+  check "sin remoto ni GITHUB_REPOSITORY → no opina" 0 $?
 fi
 
 # ── Resumen ───────────────────────────────────────────────────────────────────

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,7 +9,8 @@ Funcionan tal cual, sin importar el lenguaje del proyecto — no los borres al i
 - [`quality.yml`](quality.yml) — salud de la documentación y del tooling: formato
   Markdown (Prettier), enlaces internos, placeholders, frontmatter de skills y agentes,
   colores crudos en las vistas, herencia de la plantilla, que `develop` exista en el
-  remoto, que ningún workflow diga ser otro repositorio, la suite de pruebas de
+  remoto, que ningún workflow diga ser otro repositorio, que las labels de
+  `LABELS.md` existan de verdad, la suite de pruebas de
   [`../scripts/`](../scripts) y, en cada PR, la entrada en `CHANGELOG.md` bajo
   `## [Unreleased]` — el label `sin-changelog` es la excepción explícita. En los PRs
   hacia `main` añade el paso de release: nada llega a producción sin versión cortada.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -90,6 +90,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: bash .github/scripts/check-workflow-identity.sh
 
+      # Declarar una label en LABELS.md no la crea. Y `dependabot.yml` depende de
+      # que `sin-changelog` exista de verdad, no de que esté escrita.
+      - name: Labels declaradas y creadas
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/check-labels.sh
+
       - name: Design system — vistas sin color crudo
         if: ${{ !cancelled() }}
         run: bash .github/scripts/check-design-tokens.sh

--- a/.github/workflows/template-update-check.yml
+++ b/.github/workflows/template-update-check.yml
@@ -38,7 +38,14 @@ jobs:
             echo "changed=0" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          git clone --quiet --filter=blob:none "$repo" /tmp/tpl
+          # Un repositorio se renombra y este puntero se queda atrás: GitHub
+          # redirige un tiempo, pero si alguien reclama el nombre viejo, deja de
+          # resolver. Sin este aviso, el fallo es un 'git clone' críptico.
+          if ! git clone --quiet --filter=blob:none "$repo" /tmp/tpl 2>/dev/null; then
+            echo "::warning::No se pudo clonar $repo. Si la plantilla se renombró, actualiza 'repo=' en .template-origin."
+            echo "changed=0" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
           cd /tmp/tpl
           if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
             echo "::warning::El commit base $base no existe en la plantilla; omitiendo."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+### Added
+
+- **`check-labels.sh` — que las labels de `LABELS.md` existan de verdad en el
+  repositorio.** `LABELS.md` es la fuente única y `setup-labels.sh` las crea a partir de
+  sus tablas, pero crearlas es un paso **manual**, una vez por repositorio, y nada
+  comprobaba que se hubiera dado. Los cinco repos de esta familia tenían solo las labels
+  por defecto de GitHub: ninguna de las once declaradas existía.
+
+  No es cosmético. `dependabot.yml` declara `sin-changelog` en sus PRs para que el job
+  del changelog los deje pasar — sin la label creada, Dependabot no puede aplicarla, el
+  gate los tumba igual, y **el arreglo parece hecho porque el archivo dice lo correcto**.
+  La vía de escape manual tampoco servía: no puedes ponerle a un PR una label que no
+  existe.
+
+### Fixed
+
+- **`template-update-check.yml` reventaba con un `git clone` críptico** cuando el
+  repositorio de origen ya no resolvía. Un repo se renombra y el `repo=` de
+  `.template-origin` se queda atrás: GitHub redirige un tiempo, pero si alguien reclama el
+  nombre viejo deja de resolver. Ahora avisa de que quizá se renombró y dice qué archivo
+  tocar.
+- **La plantilla de PR citaba `docs/conventions/ai-agents.md`**, que en esta variante no
+  existe. Lo leía todo el que abría un PR, y `check-links.sh` no lo veía porque estaba
+  como `code span`, no como enlace.
+- **Cuatro comentarios de `run-tests.sh` remitían a `/instanciar` y
+  `/actualizar-plantilla`** para explicar el porqué de una regla. Aquí no hay skills:
+  ahora citan el paso o `TEMPLATE-USAGE.md`, que es lo que sí está.
+
 ## [2.2.0] - 2026-09-07
 
 ### Fixed


### PR DESCRIPTION
# Descripción

Auditoría final antes de cerrar. El hallazgo gordo **invalidaba el arreglo del PR
anterior**.

**`check-labels.sh` — que las labels de `LABELS.md` existan de verdad.** `LABELS.md` es la
fuente única y `setup-labels.sh` las crea a partir de sus tablas, pero crearlas es un paso
**manual**, una vez por repositorio, y nada comprobaba que se hubiera dado. Los cinco
repos de esta familia tenían solo las nueve labels por defecto de GitHub: **ninguna de las
once declaradas existía.**

No es cosmético. `dependabot.yml` declara `sin-changelog` en sus PRs para que el job del
changelog los deje pasar. Sin la label creada, Dependabot no puede aplicarla, el gate los
tumba igual, y **el arreglo parece hecho porque el archivo dice lo correcto**. La vía de
escape manual tampoco servía: no puedes ponerle a un PR una label que no existe. Las once
ya están creadas en los cinco repos; este check impide que vuelva a pasar.

**Y `template-update-check.yml` reventaba con un `git clone` críptico** cuando el
repositorio de origen ya no resolvía. Un repo se renombra y el `repo=` de
`.template-origin` se queda atrás: GitHub redirige un tiempo, pero si alguien reclama el
nombre viejo deja de resolver. Caso real: `brayandiazc.com` apunta a
`brayandiazc/my-starter-project`, que hoy devuelve 404. Ahora avisa de qué pasó y qué
archivo tocar.

**Y dos restos de la poda de la capa de IA**, que son el hallazgo 8 otra vez: la plantilla
de PR citaba `docs/conventions/ai-agents.md` —que aquí no existe, y `check-links.sh` no lo
veía porque estaba como `code span`, no como enlace— y cuatro comentarios de
`run-tests.sh` remitían a `/instanciar` y `/actualizar-plantilla` para explicar el porqué
de una regla. Ya no queda ninguna referencia a skills en esta variante.

## Tipo de cambio

- [x] Corrección de bug
- [x] Configuración / tooling

## Cómo comprobar que funciona

1. `bash .github/scripts/check-labels.sh .` → las 11 existen.
2. `bash .github/scripts/tests/run-tests.sh` → 0 fallidas, con 6 casos nuevos que cubren
   los dos caminos y los cuatro «no opina» (incluido el caso real: repo solo con labels
   de fábrica).
3. El check corre en `quality.yml` con `GH_TOKEN` y en `.githooks/pre-push`.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no — las labels ya están creadas en los cinco repos.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
