### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ plantilla, no su vida (ver `TEMPLATE-USAGE.md`).
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-09-07
+
 ### Added
 
 - **`check-labels.sh` — que las labels de `LABELS.md` existan de verdad en el
@@ -177,7 +179,8 @@ del repositorio. No se reconstruye aquí: inventarlo sería peor que no tenerlo.
 
 <!--
 Enlaces de comparación entre versiones:
-[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/brayandiazc/project-starter-template-es/compare/v2.0.0...v2.0.1


### PR DESCRIPTION
# Descripción

Corta la versión con `check-labels.sh` y los restos de la auditoría final. No crea el tag
— lo pone `release.yml` al fusionar en `main`.

**Minor**, como la anterior: añade un check.

Vale la pena dejar dicho qué cierra esta versión, porque la anterior no lo hacía. El
`sin-changelog` que publicó la v2.2.0 **no tenía efecto**: la label no existía en el
repositorio, así que Dependabot no podía aplicarla. El archivo decía lo correcto y el
mecanismo seguía roto. Las once labels ya están creadas y `check-labels.sh` impide que
vuelva a pasar.

## Tipo de cambio

- [x] Documentación

## Cómo comprobar que funciona

1. `bash .github/scripts/check-release.sh .` → cortada y sin publicar.
2. Al fusionar `develop` → `main`, aparecen el tag y el release.

## Lo que ninguna máquina revisa

- [x] Documentación afectada actualizada.
- [ ] Esquema de datos — no aplica.

## Impacto

- **Breaking change**: no.
- **Requiere migración**: no.
- **Algo crece sin techo**: no.

## Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDFFnodeLgFoRyMgqBxfUh
